### PR TITLE
feat: task type in feature-cm required

### DIFF
--- a/src/commands/ChangeManagement.ts
+++ b/src/commands/ChangeManagement.ts
@@ -95,7 +95,7 @@ const ChangeManagement: SlashCommand = {
       name: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TYPE,
       description: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TYPE_DESCRIPTION,
       type: ApplicationCommandOptionType.String,
-      required: false,
+      required: true,
       choices: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TYPE_CHOICES,
     },
   ],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -179,6 +179,10 @@ export const COMMAND_FEATURE_CHANGE_MANAGEMENT = {
       name: 'Documentation',
       value: 'documentation',
     },
+    {
+      name: 'None',
+      value: 'none',
+    },
   ],
 };
 

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -179,7 +179,7 @@ export async function createNotionSupportTicketsDBEntry(
  * @param authorUsername - The Discord username of the user who generated this message.
  * @param category - The category where the change management is to be applied.
  * @param description - A detailed description of the change management.
- * @param type - A ticket type of the change management. Optional parameter.
+ * @param taskType - A task type of the change management.
  * @returns {Promise<string>} - The ID of the created Notion page, or an empty string if an error occurs.
  */
 export async function createNotionBacklogDBEntry(
@@ -187,7 +187,7 @@ export async function createNotionBacklogDBEntry(
   authorUsername: string,
   category: string,
   description: string,
-  type?: string | undefined,
+  taskType: string | undefined,
 ): Promise<string> {
   try {
     let data: NotionBacklogBDEntry = {
@@ -236,10 +236,11 @@ export async function createNotionBacklogDBEntry(
       ],
     };
 
-    if (type) {
+    //When None is selected, we ignore the task type property when creating the notion page:
+    if (taskType && taskType !== 'none') {
       // Find the option name based on the type.
       const option = COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TYPE_CHOICES.find(
-        (option) => option.value === type,
+        (option) => option.value === taskType,
       );
 
       if (option) {


### PR DESCRIPTION
What I did in this Pull Request is this


1. I made the task type option in /feature-cm required, 
2. Added a new option `None`, 
3. When None is selected by user, we ignore the task type property when creating the notion page