### PR TITLE
feat: accept priority as user input during feature-cm invocation

### DIFF
--- a/src/commands/ChangeManagement.ts
+++ b/src/commands/ChangeManagement.ts
@@ -47,8 +47,8 @@ async function executeRun(interaction: CommandInteraction) {
     authorUsername,
     String(category),
     String(description),
-    taskType ? String(taskType.value) : undefined,
-    priorityType ? String(priorityType.value) : undefined,
+    String(taskType),
+    String(priorityType),
   );
 
   // Notion link uses pageID without hyphens.

--- a/src/commands/ChangeManagement.ts
+++ b/src/commands/ChangeManagement.ts
@@ -32,9 +32,14 @@ async function executeRun(interaction: CommandInteraction) {
   );
   const taskType = interaction.options.get(
     COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TASK_TYPE,
-    false,
+    true,
   );
   const authorUsername = interaction.user.username;
+
+  const priorityType = interaction.options.get(
+    COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_PRIORITY,
+    true,
+  );
 
   // Create an entry in the notion database and grab the page id.
   const pageID: string = await createNotionBacklogDBEntry(
@@ -43,6 +48,7 @@ async function executeRun(interaction: CommandInteraction) {
     String(category),
     String(description),
     taskType ? String(taskType.value) : undefined,
+    priorityType ? String(priorityType.value) : undefined,
   );
 
   // Notion link uses pageID without hyphens.
@@ -100,6 +106,13 @@ const ChangeManagement: SlashCommand = {
       type: ApplicationCommandOptionType.String,
       required: true,
       choices: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TYPE_CHOICES,
+    },
+    {
+      name: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_PRIORITY,
+      description: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_PRIORITY_DESCRIPTION,
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      choices: COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_PRIORITY_CHOICES,
     },
   ],
   run: async (_client: Client, interaction: CommandInteraction) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -184,6 +184,23 @@ export const COMMAND_FEATURE_CHANGE_MANAGEMENT = {
       value: 'none',
     },
   ],
+
+  OPTION_PRIORITY: 'priority',
+  OPTION_PRIORITY_DESCRIPTION: 'Priority level of the feature/change management request',
+  OPTION_PRIORITY_CHOICES: [
+    {
+      name: 'High 🔥',
+      value: 'high',
+    },
+    {
+      name: 'Medium',
+      value: 'medium',
+    },
+    {
+      name: 'Low',
+      value: 'low',
+    },
+  ],
 };
 
 // Support command constants

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -188,7 +188,13 @@ export async function createNotionBacklogDBEntry(
   category: string,
   description: string,
   taskType: string | undefined,
+  priorityType: string | undefined,
 ): Promise<string> {
+  // Perform reverse lookup to get the priority name
+  const priorityOption = COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_PRIORITY_CHOICES.find(
+    (priorityOption) => priorityOption.value === priorityType,
+  );
+
   try {
     let data: NotionBacklogBDEntry = {
       parent: { database_id: backlogDatabaseID },
@@ -220,6 +226,11 @@ export async function createNotionBacklogDBEntry(
             },
           ],
         },
+        Priority: {
+          select: {
+            name: priorityOption?.name || 'Medium',
+          },
+        },
       },
       children: [
         {
@@ -237,7 +248,7 @@ export async function createNotionBacklogDBEntry(
     };
 
     //When None is selected, we ignore the task type property when creating the notion page:
-    if (taskType && taskType !== 'none') {
+    if (taskType !== 'none') {
       // Find the option name based on the type.
       const option = COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_TYPE_CHOICES.find(
         (option) => option.value === taskType,

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -187,8 +187,8 @@ export async function createNotionBacklogDBEntry(
   authorUsername: string,
   category: string,
   description: string,
-  taskType: string | undefined,
-  priorityType: string | undefined,
+  taskType: string,
+  priorityType: string,
 ): Promise<string> {
   // Perform reverse lookup to get the priority name
   const priorityOption = COMMAND_FEATURE_CHANGE_MANAGEMENT.OPTION_PRIORITY_CHOICES.find(


### PR DESCRIPTION
What I did here was update the`/feature-cm` command to:

1. **Add a `priority` option** that users must specify when they invoke the `/feature-cm` command.
2. **Ensure that the `priority` option is required**.
3. **Send the priority value** to Notion when creating the task.

Here is a live View

![image](https://github.com/GitFitCode/gitfitbot/assets/56637452/7455b47d-9378-452e-9d9f-d5314a5d36e9)
