### PR TITLE
feat: weekly project pulse cron job

### DIFF
--- a/src/commands/ProjectDigest.ts
+++ b/src/commands/ProjectDigest.ts
@@ -14,41 +14,12 @@ import 'dotenv/config';
 import { SlashCommand } from '../Command';
 import {
   buildTranscriptText,
+  chunkForDiscord,
   COMMAND_PROJECT_DIGEST,
   condenseMessages,
-  DISCORD_MESSAGE_MAX_CHAR_LIMIT,
   fetchAllMessages,
   getProjectDigestResponse,
 } from '../utils';
-
-/** Split text into chunks that respect Discord's per-message character limit. */
-function chunkForDiscord(text: string, limit = DISCORD_MESSAGE_MAX_CHAR_LIMIT): string[] {
-  const chunks: string[] = [];
-  const lines = text.split('\n');
-  let current = '';
-
-  for (const line of lines) {
-    // A single line longer than the limit gets hard-split.
-    if (line.length > limit) {
-      if (current) {
-        chunks.push(current);
-        current = '';
-      }
-      for (let i = 0; i < line.length; i += limit) {
-        chunks.push(line.slice(i, i + limit));
-      }
-      continue;
-    }
-    if (current.length + line.length + 1 > limit) {
-      chunks.push(current);
-      current = line;
-    } else {
-      current = current ? `${current}\n${line}` : line;
-    }
-  }
-  if (current) chunks.push(current);
-  return chunks;
-}
 
 async function executeRun(interaction: CommandInteraction) {
   const requestedId = interaction.options.get(COMMAND_PROJECT_DIGEST.OPTION_THREAD_ID)?.value as

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -18,9 +18,10 @@ export default (client: Client): void => {
         type: ActivityType.Listening,
       });
 
-      // Start the steering reminder cron job.
+      // Start the steering reminder + weekly project pulse cron jobs.
       const cronJobs = CronJobs.getInstance(client);
       cronJobs.startGFCSteeringReminderJob();
+      cronJobs.startProjectPulseJob();
     }
 
     // Set status (i.e. activity) of the "autobot" bot.

--- a/src/scripts/runProjectPulse.ts
+++ b/src/scripts/runProjectPulse.ts
@@ -1,0 +1,37 @@
+/**
+ * Manually trigger the weekly Project Pulse once, for testing.
+ *
+ * Logs in, runs CronJobs.runProjectPulse() (which DMs the configured admin and
+ * returns the report), prints the report, and exits.
+ *
+ *   pnpm exec ts-node ./src/scripts/runProjectPulse.ts
+ */
+
+import { Client, GatewayIntentBits } from 'discord.js';
+import 'dotenv/config';
+import { CronJobs } from '../utils';
+
+const discordBotToken = process.env.DISCORD_BOT_TOKEN ?? '';
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+client.once('ready', async () => {
+  try {
+    const report = await CronJobs.getInstance(client).runProjectPulse();
+    console.log('\n===== PROJECT PULSE =====\n');
+    console.log(report);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+  } finally {
+    client.destroy();
+    process.exit(0);
+  }
+});
+
+void client.login(discordBotToken);

--- a/src/utils/channelDump.ts
+++ b/src/utils/channelDump.ts
@@ -7,6 +7,39 @@
 
 import { Collection, Message, TextBasedChannel } from 'discord.js';
 
+import { DISCORD_MESSAGE_MAX_CHAR_LIMIT } from './constants';
+
+/**
+ * Split text into chunks that respect Discord's per-message character limit,
+ * breaking on line boundaries where possible and hard-splitting overlong lines.
+ */
+export function chunkForDiscord(text: string, limit = DISCORD_MESSAGE_MAX_CHAR_LIMIT): string[] {
+  const chunks: string[] = [];
+  const lines = text.split('\n');
+  let current = '';
+
+  for (const line of lines) {
+    if (line.length > limit) {
+      if (current) {
+        chunks.push(current);
+        current = '';
+      }
+      for (let i = 0; i < line.length; i += limit) {
+        chunks.push(line.slice(i, i + limit));
+      }
+      continue;
+    }
+    if (current.length + line.length + 1 > limit) {
+      chunks.push(current);
+      current = line;
+    } else {
+      current = current ? `${current}\n${line}` : line;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
 export interface CondensedMessage {
   author: string;
   createdAt: string;
@@ -43,6 +76,38 @@ export async function fetchAllMessages(
   }
 
   return all.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+}
+
+/**
+ * Page backwards through a channel/thread's history but stop once messages are
+ * older than `sinceTs`. Returns only messages at/after the cutoff, sorted
+ * oldest -> newest. Efficient for "what happened recently" use cases.
+ */
+export async function fetchMessagesSince(
+  channel: TextBasedChannel,
+  sinceTs: number,
+): Promise<Message[]> {
+  const collected: Message[] = [];
+  let before: string | undefined;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const batch: Collection<string, Message> = await channel.messages.fetch({
+      limit: 100,
+      before,
+    });
+    if (batch.size === 0) break;
+
+    const recent = [...batch.values()].filter((m) => m.createdTimestamp >= sinceTs);
+    collected.push(...recent);
+
+    // If this page contains anything older than the cutoff, we're done.
+    const reachedCutoff = batch.some((m) => m.createdTimestamp < sinceTs);
+    if (reachedCutoff || batch.size < 100) break;
+    before = batch.last()?.id;
+  }
+
+  return collected.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
 }
 
 /** Reduce full messages to the minimal fields needed for summarization. */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,7 +39,23 @@ export const GFC_CRON_CONFIG = {
     PATTERN: '0 10 * * 2',
     TIMEZONE: 'America/Los_Angeles',
   },
+  PROJECT_PULSE: {
+    // At 09:00 on Mondays.
+    PATTERN: '0 9 * * 1',
+    TIMEZONE: 'America/Los_Angeles',
+  },
 };
+
+// The gfc-projects forum channel in the GitFitCode server; each post/thread is a
+// community project. Used by the weekly Project Pulse cron job.
+export const GFC_PROJECTS_FORUM_ID = '1032761290919260262';
+// How far back the weekly pulse looks for project activity.
+export const PROJECT_PULSE_LOOKBACK_DAYS = 7;
+// System prompt for the per-project weekly status blurb.
+export const PROJECT_PULSE_SYSTEM_PROMPT =
+  'You write a single concise status update (1-2 sentences, max ~280 chars) for a software project, based on the past week of chat messages from its thread. ' +
+  'State what actually moved this week — features shipped, decisions made, metrics, blockers. Use only what is in the messages; do not invent. ' +
+  'Be specific and plain. No preamble, no markdown headings — just the sentence(s).';
 
 // Events command constants
 export const COMMAND_EVENT = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,15 +4,26 @@ import {
   ApplicationCommandOptionChoiceData,
   ApplicationCommandOptionType,
   Client,
+  ForumChannel,
   ThreadChannel,
 } from 'discord.js';
 import 'dotenv/config';
 import {
+  buildTranscriptText,
+  chunkForDiscord,
+  condenseMessages,
+  fetchMessagesSince,
+} from './channelDump';
+import {
   COMMAND_EVENT,
+  DISCORD_MESSAGE_MAX_CHAR_LIMIT,
   GFC_CRON_CONFIG,
+  GFC_PROJECTS_FORUM_ID,
   NOTION_PAGE_ID_DELIMITER,
+  PROJECT_PULSE_LOOKBACK_DAYS,
   THREAD_START_MESSAGE_SLICE_INDEX,
 } from './constants';
+import { getProjectPulseResponse } from './openAI';
 import { GitFitCodeEventOptions } from './types';
 
 /**
@@ -196,6 +207,7 @@ export function delay(ms: number) {
 export class CronJobs {
   private static instance: CronJobs;
   private GFCSteeringReminderJob: CronJob;
+  private projectPulseJob: CronJob;
 
   constructor(private client: Client) {
     this.GFCSteeringReminderJob = new CronJob(
@@ -204,6 +216,14 @@ export class CronJobs {
       null, // onComplete
       false, // start
       GFC_CRON_CONFIG.STEERING_REMINDER.TIMEZONE, // timezone
+    );
+
+    this.projectPulseJob = new CronJob(
+      GFC_CRON_CONFIG.PROJECT_PULSE.PATTERN,
+      () => this._execute(GFC_CRON_CONFIG.PROJECT_PULSE),
+      null,
+      false,
+      GFC_CRON_CONFIG.PROJECT_PULSE.TIMEZONE,
     );
   }
 
@@ -219,6 +239,58 @@ export class CronJobs {
         console.error('Error while executing steering reminder cron job:', error);
       }
     }
+
+    // Weekly roundup of gfc-projects activity.
+    if (type === GFC_CRON_CONFIG.PROJECT_PULSE) {
+      try {
+        await this.runProjectPulse();
+      } catch (error) {
+        console.error('Error while executing project pulse cron job:', error);
+      }
+    }
+  }
+
+  /**
+   * Builds a weekly "Project Pulse" — a one-line status for each gfc-projects
+   * thread that had activity in the last {@link PROJECT_PULSE_LOOKBACK_DAYS}
+   * days — and DMs it to the configured admin. Returns the report text so it can
+   * also be triggered manually (e.g. from a script) for testing.
+   */
+  public async runProjectPulse(): Promise<string> {
+    const sinceTs = Date.now() - PROJECT_PULSE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+    const forum = (await this.client.channels.fetch(GFC_PROJECTS_FORUM_ID)) as ForumChannel;
+    const active = await forum.threads.fetchActive();
+
+    const blurbs: string[] = [];
+    for (const [, thread] of active.threads) {
+      // eslint-disable-next-line no-await-in-loop
+      const messages = await fetchMessagesSince(thread, sinceTs);
+      if (messages.length === 0) continue; // skip quiet projects
+
+      const { text } = buildTranscriptText(condenseMessages(messages), 12_000);
+      // eslint-disable-next-line no-await-in-loop
+      const summary = await getProjectPulseResponse(
+        `Project: ${thread.name}\nMessages from the past week:\n${text}`,
+      );
+      blurbs.push(`**${thread.name}** — ${summary} _(${messages.length} msgs)_`);
+    }
+
+    const heading = `📊 **Weekly Project Pulse** — last ${PROJECT_PULSE_LOOKBACK_DAYS} days`;
+    const report = blurbs.length
+      ? `${heading}\n\n${blurbs.join('\n\n')}`
+      : `${heading}\n\nNo gfc-projects threads had activity this week.`;
+
+    const adminId = process.env.ADMIN_1_DISCORD_ID;
+    if (adminId) {
+      const admin = await this.client.users.fetch(adminId);
+      for (const chunk of chunkForDiscord(report, DISCORD_MESSAGE_MAX_CHAR_LIMIT)) {
+        // eslint-disable-next-line no-await-in-loop
+        await admin.send(chunk);
+      }
+    }
+
+    return report;
   }
 
   public static getInstance(client: Client): CronJobs {
@@ -234,5 +306,13 @@ export class CronJobs {
 
   public stopGFCSteeringReminderJob() {
     this.GFCSteeringReminderJob.stop();
+  }
+
+  public startProjectPulseJob() {
+    this.projectPulseJob.start();
+  }
+
+  public stopProjectPulseJob() {
+    this.projectPulseJob.stop();
   }
 }

--- a/src/utils/openAI.ts
+++ b/src/utils/openAI.ts
@@ -6,6 +6,7 @@ import {
   OPEN_AI_API_RESPONSE_ERROR_MSG,
   OPEN_AI_CONFIG,
   PROJECT_DIGEST_SYSTEM_PROMPT,
+  PROJECT_PULSE_SYSTEM_PROMPT,
 } from './constants';
 
 /**
@@ -54,4 +55,30 @@ export async function getProjectDigestResponse(transcript: string): Promise<stri
   return response.content.toString() || OPEN_AI_API_RESPONSE_ERROR_MSG;
 }
 
-export default { getChatOpenAIPromptResponse, getProjectDigestResponse };
+/**
+ * Produces a short (1-2 sentence) weekly status blurb for a single project,
+ * based on the past week of its thread messages. Used by the Project Pulse cron.
+ *
+ * @param {string} prompt - Project name + recent messages.
+ * @returns {Promise<string>} - A concise status sentence.
+ */
+export async function getProjectPulseResponse(prompt: string): Promise<string> {
+  const chatModel = new ChatOpenAI({
+    modelName: OPEN_AI_CONFIG.MODEL,
+    temperature: 0.3,
+    openAIApiKey: process.env.OPENAI_API_KEY,
+  });
+
+  const response = await chatModel.invoke([
+    new SystemMessage(PROJECT_PULSE_SYSTEM_PROMPT),
+    new HumanMessage(prompt),
+  ]);
+
+  return response.content.toString() || OPEN_AI_API_RESPONSE_ERROR_MSG;
+}
+
+export default {
+  getChatOpenAIPromptResponse,
+  getProjectDigestResponse,
+  getProjectPulseResponse,
+};


### PR DESCRIPTION
## Summary
Adds the "continual automatic updates" layer: a weekly **Project Pulse** that auto-summarizes activity across `gfc-projects` threads and DMs a consolidated report to the admin.

- **`CronJobs.runProjectPulse()`** — resolves the `gfc-projects` forum (`GFC_PROJECTS_FORUM_ID`), finds threads with activity in the last `PROJECT_PULSE_LOOKBACK_DAYS` (7), summarizes each via gpt-4o (`getProjectPulseResponse`, concise system prompt), and DMs the chunked report to `ADMIN_1_DISCORD_ID`.
- **New cron** — Mondays 09:00 PT; started for GitFitBot in `ready.ts` alongside the steering reminder.
- **`fetchMessagesSince()`** — efficient recent-history fetch (stops paging past the cutoff); **`chunkForDiscord()`** extracted to the shared util and reused by `/project-digest`.
- **`src/scripts/runProjectPulse.ts`** — manual one-off trigger for testing.

## Test plan
- [x] `pnpm typecheck` / `format:check` / `build` clean
- [x] Ran the trigger script live: Discord path works end-to-end (connects, resolves forum, fetches threads/messages) up to the LLM call
- [ ] Full output blocked by **OpenAI quota (429)** on the key in `.env` — needs billing top-up; not a code issue

## Note
The OpenAI key is valid but out of quota, which also affects the already-merged `/project-digest`. Once billing is restored, both produce output with no code changes.