### PR TITLE
feat: persist /model choice across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,7 @@ exports/
 
 # Local env backups (contain secrets)
 .env.bak*
+
+# PouchDB local stores (runtime)
+attendees_db/
+settings_db/

--- a/src/commands/Model.ts
+++ b/src/commands/Model.ts
@@ -29,8 +29,8 @@ async function executeRun(interaction: CommandInteraction) {
     return;
   }
 
-  setActiveModel(requested);
-  await interaction.editReply(`Model switched to \`${requested}\`.`);
+  await setActiveModel(requested);
+  await interaction.editReply(`Model switched to \`${requested}\`. (persists across restarts)`);
 }
 
 const Model: SlashCommand = {

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -4,13 +4,16 @@
 
 import { ActivityType, Client } from 'discord.js';
 import Commands from '../Commands';
-import { AUTOBOT, CronJobs, GITFITBOT } from '../utils';
+import { AUTOBOT, CronJobs, GITFITBOT, loadPersistedModel } from '../utils';
 
 export default (client: Client): void => {
   client.on('ready', async () => {
     if (!client.user || !client.application) {
       return;
     }
+
+    // Restore the persisted /model choice (overrides env/default).
+    await loadPersistedModel();
 
     // Set status (i.e. activity) of the "GitFitBot" bot.
     if (client.user.username.toLowerCase() === GITFITBOT) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,6 +37,8 @@ export const ANTHROPIC_MODELS = {
 // active model can be overridden at boot via the ANTHROPIC_MODEL env var, or at
 // runtime by admins via the /model slash command. Note: Opus/Sonnet 4.x reject
 // temperature/top_p/stop (they 400), so the model is steered via prompts only.
+// PouchDB settings key under which the active model is persisted.
+export const ACTIVE_MODEL_SETTING_KEY = 'active_model';
 export const ANTHROPIC_CONFIG = {
   DEFAULT_MODEL: ANTHROPIC_MODELS.HAIKU,
   MAX_TOKENS: {

--- a/src/utils/localdb.ts
+++ b/src/utils/localdb.ts
@@ -3,6 +3,52 @@ import { Attendee } from './types';
 
 let attendeesDB: PouchDB.Database<Attendee>;
 
+interface Setting {
+  _id: string;
+  value: string;
+}
+
+let settingsDB: PouchDB.Database<Setting>;
+
+/** Opens (once) a small key/value database for persisted bot settings. */
+function openSettingsDatabase() {
+  if (!settingsDB) {
+    settingsDB = new PouchDB<Setting>('settings_db');
+  }
+}
+
+/**
+ * Reads a persisted setting by key.
+ *
+ * @param {string} key - The setting key.
+ * @returns {Promise<string | undefined>} The stored value, or undefined if unset.
+ */
+export async function getSetting(key: string): Promise<string | undefined> {
+  openSettingsDatabase();
+  try {
+    const doc = await settingsDB.get(key);
+    return doc.value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Persists a setting by key (upsert).
+ *
+ * @param {string} key - The setting key.
+ * @param {string} value - The value to store.
+ */
+export async function setSetting(key: string, value: string): Promise<void> {
+  openSettingsDatabase();
+  try {
+    const doc = await settingsDB.get(key);
+    await settingsDB.put({ ...doc, value });
+  } catch {
+    await settingsDB.put({ _id: key, value });
+  }
+}
+
 /**
  * Opens a new connection to the Attendees database.
  */

--- a/src/utils/openAI.ts
+++ b/src/utils/openAI.ts
@@ -10,18 +10,21 @@
 import Anthropic from '@anthropic-ai/sdk';
 import 'dotenv/config';
 import {
+  ACTIVE_MODEL_SETTING_KEY,
   ANTHROPIC_CONFIG,
   GENERAL_GFC_SYSTEM_PROMPT,
   OPEN_AI_API_RESPONSE_ERROR_MSG,
   PROJECT_DIGEST_SYSTEM_PROMPT,
   PROJECT_PULSE_SYSTEM_PROMPT,
 } from './constants';
+import { getSetting, setSetting } from './localdb';
 
 // Reads ANTHROPIC_API_KEY from the environment.
 const anthropic = new Anthropic();
 
 // The active model. Initialized from the ANTHROPIC_MODEL env var (if set),
-// otherwise the cheapest default. Mutable at runtime via the /model command.
+// otherwise the cheapest default. A persisted /model choice overrides this once
+// loadPersistedModel() runs at startup.
 let activeModel = process.env.ANTHROPIC_MODEL || ANTHROPIC_CONFIG.DEFAULT_MODEL;
 
 /** Returns the model currently used for all Claude calls. */
@@ -29,9 +32,24 @@ export function getActiveModel(): string {
   return activeModel;
 }
 
-/** Sets the model used for all subsequent Claude calls (resets on restart). */
-export function setActiveModel(model: string): void {
+/**
+ * Sets the model used for all subsequent Claude calls and persists the choice
+ * so it survives a bot restart.
+ */
+export async function setActiveModel(model: string): Promise<void> {
   activeModel = model;
+  await setSetting(ACTIVE_MODEL_SETTING_KEY, model);
+}
+
+/**
+ * Loads the persisted model choice (set via /model) on startup, overriding the
+ * env/default. No-op if nothing has been persisted yet.
+ */
+export async function loadPersistedModel(): Promise<void> {
+  const stored = await getSetting(ACTIVE_MODEL_SETTING_KEY);
+  if (stored) {
+    activeModel = stored;
+  }
 }
 
 /** Concatenate the text blocks of a Claude response, or return the error msg. */


### PR DESCRIPTION
## Summary
Makes the `/model` selection durable. Previously the active model reset to the default (Haiku) / `ANTHROPIC_MODEL` env on every restart; now it's persisted.

- New `getSetting`/`setSetting` key-value helpers on a PouchDB `settings_db`.
- `setActiveModel` persists the choice; `loadPersistedModel` restores it in the `ready` listener, overriding env/default.
- Gitignores the runtime PouchDB dirs (`attendees_db/`, `settings_db/`).

## Test plan
- [x] typecheck / format:check / build clean
- [x] Verified: set→opus, fresh process boots at default, `loadPersistedModel` restores opus; reset persisted value back to Haiku afterward