### PR TITLE
fix: usable pulse window (30d) + instant guild slash commands

### DIFF
--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -32,8 +32,17 @@ export default (client: Client): void => {
       client.user.setActivity('the world slowly 🔥 itself', { type: ActivityType.Watching });
     }
 
-    // Register slash commands with the client.
-    await client.application.commands.set(Commands);
+    // Register slash commands. Guild-scoped registration is near-instant, so
+    // prefer it when DISCORD_SERVER_ID is set; global registration can take up
+    // to ~1 hour to propagate to clients. Clear global commands first to avoid
+    // showing duplicates alongside the guild ones.
+    const guildId = process.env.DISCORD_SERVER_ID;
+    if (guildId) {
+      await client.application.commands.set([]);
+      await client.application.commands.set(Commands, guildId);
+    } else {
+      await client.application.commands.set(Commands);
+    }
 
     console.log(`${client.user.username} is online`);
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -78,7 +78,10 @@ export const GFC_CRON_CONFIG = {
 // community project. Used by the weekly Project Pulse cron job.
 export const GFC_PROJECTS_FORUM_ID = '1032761290919260262';
 // How far back the weekly pulse looks for project activity.
-export const PROJECT_PULSE_LOOKBACK_DAYS = 7;
+// 30 days — GFC project threads don't get daily traffic, so a 7-day window
+// missed most real activity (e.g. a thread with 38 msgs over the month but 1 in
+// the last week). Override at boot via the PROJECT_PULSE_LOOKBACK_DAYS env var.
+export const PROJECT_PULSE_LOOKBACK_DAYS = Number(process.env.PROJECT_PULSE_LOOKBACK_DAYS) || 30;
 // System prompt for the per-project weekly status blurb.
 export const PROJECT_PULSE_SYSTEM_PROMPT =
   'You write a single concise status update (1-2 sentences, max ~280 chars) for a software project, based on the past week of chat messages from its thread. ' +


### PR DESCRIPTION
## Summary
Two fixes from live testing:
1. **Pulse window 7→30 days** (env-overridable). A 7-day window missed real activity — e.g. the finance-brain thread had **38 messages in 30 days but only 1 in the last 7**, so the pulse reported 'no update'. GFC threads get weekly, not daily, traffic.
2. **Instant slash-command registration.** Commands were registered **globally** (~1h to appear in clients). Now registered to `DISCORD_SERVER_ID` (near-instant); clears global first to avoid duplicates.

## Test plan
- [x] typecheck / format:check / build clean
- [ ] After deploy: `/model` + `/project-digest` appear immediately; pulse surfaces finance-brain (38 msgs) with a real summary