### PR TITLE
feat: /project-digest thread picker (autocomplete)

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -2,9 +2,16 @@
  * Structure of a slash command.
  */
 
-import { ChatInputApplicationCommandData, Client, CommandInteraction } from 'discord.js';
+import {
+  AutocompleteInteraction,
+  ChatInputApplicationCommandData,
+  Client,
+  CommandInteraction,
+} from 'discord.js';
 
 export interface SlashCommand extends ChatInputApplicationCommandData {
   // Property to be called when the command is executed.
   run: (client: Client, interaction: CommandInteraction) => void;
+  // Optional handler for autocomplete interactions on this command's options.
+  autocomplete?: (client: Client, interaction: AutocompleteInteraction) => Promise<void>;
 }

--- a/src/commands/ProjectDigest.ts
+++ b/src/commands/ProjectDigest.ts
@@ -1,15 +1,19 @@
 /**
  * Slash command that summarizes a `gfc-projects` thread into a structured
- * digest + reusable playbook, and posts it back into the thread.
+ * digest + reusable playbook, and posts it back.
  *
- * This is the "systematize community projects" feature: point it at any project
- * thread and get a repeatable case study (what it is, stack, timeline, process,
- * playbook, open threads) so the lessons can be applied to the next project.
- *
- * To trigger, type `/project-digest` in (or referencing) a project thread.
+ * Usage:
+ *   - Run `/project-digest` inside a project thread → digests that thread.
+ *   - Run it anywhere (incl. DMs) and use the `project` option → a searchable
+ *     dropdown of project threads by name (autocomplete).
  */
 
-import { ApplicationCommandOptionType, Client, CommandInteraction } from 'discord.js';
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  Client,
+  CommandInteraction,
+} from 'discord.js';
 import 'dotenv/config';
 import { SlashCommand } from '../Command';
 import {
@@ -19,18 +23,29 @@ import {
   condenseMessages,
   fetchAllMessages,
   getProjectDigestResponse,
+  GFC_PROJECTS_FORUM_ID,
+  listForumThreads,
 } from '../utils';
 
 async function executeRun(interaction: CommandInteraction) {
-  const requestedId = interaction.options.get(COMMAND_PROJECT_DIGEST.OPTION_THREAD_ID)?.value as
+  const requestedId = interaction.options.get(COMMAND_PROJECT_DIGEST.OPTION_PROJECT)?.value as
     | string
     | undefined;
   const targetId = requestedId ?? interaction.channelId;
 
   const channel = await interaction.client.channels.fetch(targetId).catch(() => null);
+
+  // No project picked and not run inside a thread → tell them how to pick one.
+  if (!requestedId && (!channel || !channel.isThread())) {
+    await interaction.editReply(
+      'Run this **inside a project thread**, or use the `project` option to pick one by name.',
+    );
+    return;
+  }
+
   if (!channel || !('messages' in channel)) {
     await interaction.editReply(
-      `Could not read channel/thread \`${targetId}\` — make sure the ID is valid and the bot can see it.`,
+      `Could not read that thread — make sure the bot can see it (\`${targetId}\`).`,
     );
     return;
   }
@@ -66,20 +81,41 @@ async function executeRun(interaction: CommandInteraction) {
   }
 }
 
+/** Autocomplete: searchable list of gfc-projects threads by name. */
+async function autocomplete(_client: Client, interaction: AutocompleteInteraction) {
+  const focused = interaction.options.getFocused().toString().toLowerCase();
+
+  let threads: { id: string; name: string }[] = [];
+  try {
+    threads = await listForumThreads(interaction.client, GFC_PROJECTS_FORUM_ID);
+  } catch {
+    /* respond empty on failure rather than erroring the interaction */
+  }
+
+  const choices = threads
+    .filter((t) => !focused || t.name.toLowerCase().includes(focused))
+    .slice(0, 25)
+    .map((t) => ({ name: t.name.slice(0, 100), value: t.id }));
+
+  await interaction.respond(choices);
+}
+
 const ProjectDigest: SlashCommand = {
   name: COMMAND_PROJECT_DIGEST.COMMAND_NAME,
   description: COMMAND_PROJECT_DIGEST.COMMAND_DESCRIPTION,
   options: [
     {
-      name: COMMAND_PROJECT_DIGEST.OPTION_THREAD_ID,
-      description: COMMAND_PROJECT_DIGEST.OPTION_THREAD_ID_DESCRIPTION,
+      name: COMMAND_PROJECT_DIGEST.OPTION_PROJECT,
+      description: COMMAND_PROJECT_DIGEST.OPTION_PROJECT_DESCRIPTION,
       type: ApplicationCommandOptionType.String,
       required: false,
+      autocomplete: true,
     },
   ],
   run: async (_client: Client, interaction: CommandInteraction) => {
     await executeRun(interaction);
   },
+  autocomplete,
 };
 
 export default ProjectDigest;

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -74,6 +74,15 @@ const handleModalSubmission = async (interaction: ModalSubmitInteraction<CacheTy
 
 export default (client: Client): void => {
   client.on('interactionCreate', async (interaction: Interaction) => {
+    // Route autocomplete interactions to the matching command's handler.
+    if (interaction.isAutocomplete()) {
+      const slashCommand = Commands.find((c) => c.name === interaction.commandName);
+      if (slashCommand?.autocomplete) {
+        await slashCommand.autocomplete(client, interaction);
+      }
+      return;
+    }
+
     // Check if interaction is a command and call handleSlashCommand() if so.
     if (interaction.type === InteractionType.ApplicationCommand) {
       await handleSlashCommand(client, interaction);

--- a/src/utils/channelDump.ts
+++ b/src/utils/channelDump.ts
@@ -5,9 +5,44 @@
  * slash command so message-fetching logic lives in one place.
  */
 
-import { Collection, Message, TextBasedChannel } from 'discord.js';
+import { AnyThreadChannel, Client, Collection, Message, TextBasedChannel } from 'discord.js';
 
 import { DISCORD_MESSAGE_MAX_CHAR_LIMIT } from './constants';
+
+export interface ForumThreadRef {
+  id: string;
+  name: string;
+}
+
+/**
+ * Lists every thread (active + archived) in a forum channel as {id, name},
+ * newest-id first. Used to power the /project-digest thread picker.
+ */
+export async function listForumThreads(client: Client, forumId: string): Promise<ForumThreadRef[]> {
+  const channel = await client.channels.fetch(forumId);
+  const holder = channel as unknown as {
+    threads: {
+      fetchActive: () => Promise<{ threads: Collection<string, AnyThreadChannel> }>;
+      fetchArchived: () => Promise<{ threads: Collection<string, AnyThreadChannel> }>;
+    };
+  };
+
+  const byId = new Map<string, string>();
+  try {
+    (await holder.threads.fetchActive()).threads.forEach((t) => byId.set(t.id, t.name));
+  } catch {
+    /* ignore */
+  }
+  try {
+    (await holder.threads.fetchArchived()).threads.forEach((t) => byId.set(t.id, t.name));
+  } catch {
+    /* ignore */
+  }
+
+  return [...byId.entries()]
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => b.id.localeCompare(a.id));
+}
 
 /**
  * Split text into chunks that respect Discord's per-message character limit,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -278,9 +278,9 @@ export const COMMAND_PROJECT_DIGEST = {
   COMMAND_NAME: 'project-digest',
   COMMAND_DESCRIPTION:
     'Summarize a gfc-projects thread into a structured digest + reusable playbook.',
-  OPTION_THREAD_ID: 'thread_id',
-  OPTION_THREAD_ID_DESCRIPTION:
-    'Channel/thread ID to digest. Defaults to the channel where you run this.',
+  OPTION_PROJECT: 'project',
+  OPTION_PROJECT_DESCRIPTION:
+    'Pick a project thread by name. Leave empty to digest the thread you run this in.',
 };
 
 // System prompt that turns a project thread transcript into a structured,


### PR DESCRIPTION
## Summary
Improves `/project-digest` UX:
- **In a thread:** run `/project-digest` → digests the current thread.
- **Anywhere / DM:** the `project` option is now an **autocomplete picker** showing gfc-projects threads **by name** (no pasting IDs).

Adds an optional `autocomplete` handler to `SlashCommand`, routes autocomplete in `interactionCreate`, and a `listForumThreads` helper.

## Test plan
- [x] typecheck / format:check / build clean
- [ ] After deploy: `project` option shows thread names; running in a thread digests it