### PR TITLE
feat: digest corrections + community feedback

### DIFF
--- a/src/commands/ProjectDigest.ts
+++ b/src/commands/ProjectDigest.ts
@@ -10,36 +10,20 @@
 
 import {
   ApplicationCommandOptionType,
-  AttachmentBuilder,
   AutocompleteInteraction,
   Client,
   CommandInteraction,
-  EmbedBuilder,
 } from 'discord.js';
 import 'dotenv/config';
 import { SlashCommand } from '../Command';
 import {
-  buildTranscriptText,
+  buildDigestPayload,
   COMMAND_PROJECT_DIGEST,
-  condenseMessages,
-  fetchAllMessages,
-  getProjectDigestResponse,
+  DIGEST_INTERACTION,
+  generateDigest,
   GFC_PROJECTS_FORUM_ID,
   listForumThreads,
-  upsertPostDigest,
 } from '../utils';
-
-const EMBED_DESCRIPTION_LIMIT = 4096;
-
-/** Safe filename slug for the attached digest. */
-function fileSlug(name: string): string {
-  return (
-    name
-      .replace(/[^a-z0-9-_]+/gi, '-')
-      .replace(/^-+|-+$/g, '')
-      .toLowerCase() || 'project'
-  );
-}
 
 async function executeRun(interaction: CommandInteraction) {
   const requestedId = interaction.options.get(COMMAND_PROJECT_DIGEST.OPTION_PROJECT)?.value as
@@ -65,52 +49,26 @@ async function executeRun(interaction: CommandInteraction) {
   }
 
   const channelName = 'name' in channel ? (channel.name ?? targetId) : targetId;
-  await interaction.editReply(`📥 Reading history of **${channelName}**...`);
+  await interaction.editReply(
+    `🧠 Digesting **${channelName}** (reading history + summarizing, this can take a moment)...`,
+  );
 
-  const messages = await fetchAllMessages(channel);
-  if (messages.length === 0) {
+  const result = await generateDigest(channel, targetId);
+  if (result.empty) {
     await interaction.editReply(`**${channelName}** has no readable messages to digest.`);
     return;
   }
 
-  await interaction.editReply(
-    `🧠 Digesting **${messages.length}** messages from **${channelName}** (this can take a moment)...`,
-  );
+  await interaction.editReply({ content: '', ...buildDigestPayload(result, targetId) });
 
-  const { text, truncated } = buildTranscriptText(condenseMessages(messages));
-  const digest = await getProjectDigestResponse(text);
-
-  // Persist the digest (1 post = 1 row in discord_post_digests).
-  const saved = await upsertPostDigest({
-    discordPostId: targetId,
-    guildId: interaction.guildId,
-    name: String(channelName),
-    digest,
-    messageCount: messages.length,
-  });
-  // Build a clean embed + attach the full digest as a markdown file, instead of
-  // dumping chunked text walls (which render poorly in Discord).
-  const footerParts = [`${messages.length} messages`];
-  if (truncated) footerParts.push('truncated to recent context');
-  if (saved) footerParts.push(saved.linkedProjectId ? 'linked to a project' : 'not yet linked');
-
-  const embed = new EmbedBuilder()
-    .setColor(0x57f287)
-    .setTitle(`📋 Project Digest — ${channelName}`.slice(0, 256))
-    .setDescription(
-      digest.length > EMBED_DESCRIPTION_LIMIT
-        ? `${digest.slice(0, EMBED_DESCRIPTION_LIMIT - 60)}\n\n*…full digest attached below.*`
-        : digest,
-    )
-    .setFooter({ text: `${footerParts.join(' · ')}${saved ? ' · 💾 saved' : ''}` })
-    .setTimestamp();
-
-  const attachment = new AttachmentBuilder(
-    Buffer.from(`# Project Digest — ${channelName}\n\n${digest}\n`, 'utf8'),
-    { name: `${fileSlug(String(channelName))}-digest.md` },
-  );
-
-  await interaction.editReply({ content: '', embeds: [embed], files: [attachment] });
+  // Add community sentiment reactions to the digest message.
+  const reply = await interaction.fetchReply().catch(() => null);
+  if (reply) {
+    for (const emoji of DIGEST_INTERACTION.REACTIONS) {
+      // eslint-disable-next-line no-await-in-loop
+      await reply.react(emoji).catch(() => null);
+    }
+  }
 }
 
 /** Autocomplete: searchable list of gfc-projects threads by name. */

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -11,7 +11,7 @@ import {
   ModalSubmitInteraction,
 } from 'discord.js';
 import Commands from '../Commands';
-import { COMMAND_STANDUP } from '../utils';
+import { COMMAND_STANDUP, handleDigestButton, handleDigestModal } from '../utils';
 
 // All commands that invoke a modal should be listed here.
 const dontDeferCommandsList = [COMMAND_STANDUP.COMMAND_NAME];
@@ -80,6 +80,18 @@ export default (client: Client): void => {
       if (slashCommand?.autocomplete) {
         await slashCommand.autocomplete(client, interaction);
       }
+      return;
+    }
+
+    // Digest correction/feedback buttons.
+    if (interaction.isButton() && interaction.customId.startsWith('digest:')) {
+      await handleDigestButton(interaction);
+      return;
+    }
+
+    // Digest correction/feedback modal submissions.
+    if (interaction.isModalSubmit() && interaction.customId.startsWith('digest:')) {
+      await handleDigestModal(interaction);
       return;
     }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -283,6 +283,20 @@ export const COMMAND_PROJECT_DIGEST = {
     'Pick a project thread by name. Leave empty to digest the thread you run this in.',
 };
 
+// Component IDs + copy for digest correction/feedback interactions. Button and
+// modal custom IDs are suffixed with `:<postId>` at build time.
+export const DIGEST_INTERACTION = {
+  CORRECT_BUTTON: 'digest:correct',
+  FEEDBACK_BUTTON: 'digest:feedback',
+  CORRECT_MODAL: 'digest:correctModal',
+  FEEDBACK_MODAL: 'digest:feedbackModal',
+  CORRECTION_INPUT: 'correctionInput',
+  FEEDBACK_INPUT: 'feedbackInput',
+  REACTIONS: ['👍', '👎', '🤔'],
+  NOT_ALLOWED_MSG:
+    'Only the post author or an admin can submit corrections — use the 💬 Feedback button instead.',
+};
+
 // System prompt that turns a project thread transcript into a structured,
 // reusable case study for GitFitCode community projects.
 export const PROJECT_DIGEST_SYSTEM_PROMPT =

--- a/src/utils/digest.ts
+++ b/src/utils/digest.ts
@@ -1,0 +1,219 @@
+/**
+ * Shared digest engine: generate a post's digest, render it as a Discord embed
+ * + attachment with correction/feedback buttons, and handle those interactions.
+ *
+ * Used by the /project-digest command and the button/modal handlers so the same
+ * rendering + regeneration logic lives in one place.
+ */
+
+import {
+  ActionRowBuilder,
+  AttachmentBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  EmbedBuilder,
+  ModalBuilder,
+  ModalSubmitInteraction,
+  TextBasedChannel,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+import 'dotenv/config';
+import { buildTranscriptText, condenseMessages, fetchAllMessages } from './channelDump';
+import { DIGEST_INTERACTION } from './constants';
+import { getProjectDigestResponse } from './openAI';
+import { addDigestFeedback, listCorrections, upsertPostDigest } from './projectsDb';
+
+const EMBED_DESCRIPTION_LIMIT = 4096;
+
+const ADMIN_IDS = [process.env.ADMIN_1_DISCORD_ID, process.env.ADMIN_2_DISCORD_ID].filter(
+  (id): id is string => Boolean(id),
+);
+
+type NamedChannel = TextBasedChannel & { name?: string | null; guildId?: string | null };
+
+export interface DigestResult {
+  channelName: string;
+  digest: string;
+  messageCount: number;
+  truncated: boolean;
+  saved: { id: string; linkedProjectId: string | null } | null;
+  empty: boolean;
+}
+
+function fileSlug(name: string): string {
+  return (
+    name
+      .replace(/[^a-z0-9-_]+/gi, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase() || 'project'
+  );
+}
+
+/**
+ * Fetches a post's full history, generates the digest (folding in any stored
+ * author/admin corrections), persists it, and returns the result.
+ */
+export async function generateDigest(channel: NamedChannel, postId: string): Promise<DigestResult> {
+  const channelName = String(channel.name ?? postId);
+  const messages = await fetchAllMessages(channel);
+  if (messages.length === 0) {
+    return { channelName, digest: '', messageCount: 0, truncated: false, saved: null, empty: true };
+  }
+
+  const { text, truncated } = buildTranscriptText(condenseMessages(messages));
+  const corrections = await listCorrections(postId);
+  const digest = await getProjectDigestResponse(text, corrections);
+  const saved = await upsertPostDigest({
+    discordPostId: postId,
+    guildId: channel.guildId ?? null,
+    name: channelName,
+    digest,
+    messageCount: messages.length,
+  });
+
+  return { channelName, digest, messageCount: messages.length, truncated, saved, empty: false };
+}
+
+/** Builds the embed + .md attachment + correction/feedback buttons for a digest. */
+export function buildDigestPayload(result: DigestResult, postId: string) {
+  const { channelName, digest, messageCount, truncated, saved } = result;
+
+  const footerParts = [`${messageCount} messages`];
+  if (truncated) footerParts.push('truncated to recent context');
+  if (saved) footerParts.push(saved.linkedProjectId ? 'linked to a project' : 'not yet linked');
+
+  const embed = new EmbedBuilder()
+    .setColor(0x57f287)
+    .setTitle(`📋 Project Digest — ${channelName}`.slice(0, 256))
+    .setDescription(
+      digest.length > EMBED_DESCRIPTION_LIMIT
+        ? `${digest.slice(0, EMBED_DESCRIPTION_LIMIT - 60)}\n\n*…full digest attached below.*`
+        : digest,
+    )
+    .setFooter({ text: `${footerParts.join(' · ')}${saved ? ' · 💾 saved' : ''}` })
+    .setTimestamp();
+
+  const attachment = new AttachmentBuilder(
+    Buffer.from(`# Project Digest — ${channelName}\n\n${digest}\n`, 'utf8'),
+    { name: `${fileSlug(channelName)}-digest.md` },
+  );
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${DIGEST_INTERACTION.CORRECT_BUTTON}:${postId}`)
+      .setLabel('Suggest correction')
+      .setEmoji('✏️')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`${DIGEST_INTERACTION.FEEDBACK_BUTTON}:${postId}`)
+      .setLabel('Feedback')
+      .setEmoji('💬')
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return { embeds: [embed], files: [attachment], components: [row] };
+}
+
+/** True if the user authored the post (thread owner) or is a configured admin. */
+async function canCorrect(interaction: ButtonInteraction, postId: string): Promise<boolean> {
+  if (ADMIN_IDS.includes(interaction.user.id)) {
+    return true;
+  }
+  const channel = await interaction.client.channels.fetch(postId).catch(() => null);
+  const ownerId = channel && 'ownerId' in channel ? (channel.ownerId ?? null) : null;
+  return ownerId === interaction.user.id;
+}
+
+/** Handles the ✏️ correction / 💬 feedback buttons by opening the right modal. */
+export async function handleDigestButton(interaction: ButtonInteraction): Promise<void> {
+  const [, action, postId] = interaction.customId.split(':');
+  if (!postId) {
+    return;
+  }
+
+  if (`digest:${action}` === DIGEST_INTERACTION.FEEDBACK_BUTTON) {
+    const input = new TextInputBuilder()
+      .setCustomId(DIGEST_INTERACTION.FEEDBACK_INPUT)
+      .setLabel('Your feedback on this digest')
+      .setStyle(TextInputStyle.Short)
+      .setMaxLength(300)
+      .setRequired(true);
+    const modal = new ModalBuilder()
+      .setCustomId(`${DIGEST_INTERACTION.FEEDBACK_MODAL}:${postId}`)
+      .setTitle('Digest feedback')
+      .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    await interaction.showModal(modal);
+    return;
+  }
+
+  // Correction button — gated to the post author + admins.
+  if (!(await canCorrect(interaction, postId))) {
+    await interaction.reply({ ephemeral: true, content: DIGEST_INTERACTION.NOT_ALLOWED_MSG });
+    return;
+  }
+  const input = new TextInputBuilder()
+    .setCustomId(DIGEST_INTERACTION.CORRECTION_INPUT)
+    .setLabel('What should the digest say instead?')
+    .setStyle(TextInputStyle.Paragraph)
+    .setMaxLength(1000)
+    .setRequired(true);
+  const modal = new ModalBuilder()
+    .setCustomId(`${DIGEST_INTERACTION.CORRECT_MODAL}:${postId}`)
+    .setTitle('Correct this digest')
+    .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+  await interaction.showModal(modal);
+}
+
+/** Handles correction/feedback modal submissions (and regenerates on correction). */
+export async function handleDigestModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const [, type, postId] = interaction.customId.split(':');
+  if (!postId) {
+    return;
+  }
+  const userName = interaction.user.tag ?? interaction.user.username;
+
+  // Community feedback — just record it.
+  if (`digest:${type}` === DIGEST_INTERACTION.FEEDBACK_MODAL) {
+    const content = interaction.fields.getTextInputValue(DIGEST_INTERACTION.FEEDBACK_INPUT);
+    await addDigestFeedback({
+      discordPostId: postId,
+      discordUserId: interaction.user.id,
+      userName,
+      kind: 'feedback',
+      content,
+    });
+    await interaction.reply({
+      ephemeral: true,
+      content: '💬 Thanks — your feedback was recorded.',
+    });
+    return;
+  }
+
+  // Author/admin correction — record it, then regenerate the digest in place.
+  const content = interaction.fields.getTextInputValue(DIGEST_INTERACTION.CORRECTION_INPUT);
+  await interaction.deferReply({ ephemeral: true });
+  await addDigestFeedback({
+    discordPostId: postId,
+    discordUserId: interaction.user.id,
+    userName,
+    kind: 'correction',
+    content,
+  });
+
+  const channel = await interaction.client.channels.fetch(postId).catch(() => null);
+  if (!channel || !('messages' in channel)) {
+    await interaction.editReply(
+      'Correction saved, but I could not re-read the thread to regenerate.',
+    );
+    return;
+  }
+
+  const result = await generateDigest(channel as NamedChannel, postId);
+  if (!result.empty && interaction.message) {
+    const payload = buildDigestPayload(result, postId);
+    await interaction.message.edit(payload).catch(() => null);
+  }
+  await interaction.editReply('✏️ Correction saved — digest updated.');
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './channelDump';
 export * from './constants';
+export * from './digest';
 export * from './helpers';
 export * from './localdb';
 export * from './notion';

--- a/src/utils/openAI.ts
+++ b/src/utils/openAI.ts
@@ -86,13 +86,25 @@ export async function getChatOpenAIPromptResponse(prompt: string): Promise<strin
  * @param {string} transcript - The plain-text thread transcript to digest.
  * @returns {Promise<string>} - The markdown digest.
  */
-export async function getProjectDigestResponse(transcript: string): Promise<string> {
+export async function getProjectDigestResponse(
+  transcript: string,
+  corrections: string[] = [],
+): Promise<string> {
+  const correctionBlock = corrections.length
+    ? `\n\nThe project author/admins have provided these corrections — treat them as AUTHORITATIVE and make sure the digest reflects them, overriding anything in the transcript that conflicts:\n${corrections
+        .map((c, i) => `${i + 1}. ${c}`)
+        .join('\n')}`
+    : '';
+
   const message = await anthropic.messages.create({
     model: getActiveModel(),
     max_tokens: ANTHROPIC_CONFIG.MAX_TOKENS.DIGEST,
     system: PROJECT_DIGEST_SYSTEM_PROMPT,
     messages: [
-      { role: 'user', content: `Here is the full project thread transcript:\n\n${transcript}` },
+      {
+        role: 'user',
+        content: `Here is the full project thread transcript:\n\n${transcript}${correctionBlock}`,
+      },
     ],
   });
 

--- a/src/utils/projectsDb.ts
+++ b/src/utils/projectsDb.ts
@@ -75,3 +75,52 @@ export async function upsertPostDigest(input: PostDigestInput): Promise<SavedPos
     return null;
   }
 }
+
+export type FeedbackKind = 'correction' | 'feedback';
+
+export interface FeedbackInput {
+  discordPostId: string;
+  discordUserId: string;
+  userName: string;
+  kind: FeedbackKind;
+  content: string;
+}
+
+/** Records a correction (author/admin) or community feedback for a post. */
+export async function addDigestFeedback(input: FeedbackInput): Promise<boolean> {
+  const db = getPool();
+  if (!db) {
+    return false;
+  }
+  try {
+    await db.query(
+      `insert into digest_feedback (discord_post_id, discord_user_id, user_name, kind, content)
+       values ($1, $2, $3, $4, $5)`,
+      [input.discordPostId, input.discordUserId, input.userName, input.kind, input.content],
+    );
+    return true;
+  } catch (err) {
+    console.error('Failed to record digest feedback:', (err as Error).message);
+    return false;
+  }
+}
+
+/** Returns all correction texts for a post, oldest first (for regeneration). */
+export async function listCorrections(discordPostId: string): Promise<string[]> {
+  const db = getPool();
+  if (!db) {
+    return [];
+  }
+  try {
+    const result = await db.query(
+      `select content from digest_feedback
+       where discord_post_id = $1 and kind = 'correction'
+       order by created_at asc`,
+      [discordPostId],
+    );
+    return result.rows.map((r) => r.content as string);
+  } catch (err) {
+    console.error('Failed to list corrections:', (err as Error).message);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
Closes the loop on digests: authors/admins correct them, the community reacts.

- **✏️ Suggest correction** button (gated to **post author + admins**) → modal → records the correction in `digest_feedback` → **regenerates the digest in place** with corrections treated as authoritative (overriding the transcript).
- **💬 Feedback** button (anyone) → short modal → recorded as community feedback (does not change the digest).
- Bot adds **👍/👎/🤔** reactions to each digest for quick sentiment.
- New `digest_feedback` table; `getProjectDigestResponse(transcript, corrections)`; shared engine `utils/digest.ts` used by the command + handlers.

## Test plan
- [x] typecheck / format:check / build clean
- [x] Verified: corrections stored (feedback excluded from corrections list); a correction ('it's MoneyBrain not Finance Brain') regenerated the digest with the new name
- [ ] After deploy: click ✏️ as author/admin → modal → digest updates; click 💬 as anyone → feedback saved; reactions present