### PR TITLE
feat: use Sonnet for digests

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -41,6 +41,10 @@ export const ANTHROPIC_MODELS = {
 export const ACTIVE_MODEL_SETTING_KEY = 'active_model';
 export const ANTHROPIC_CONFIG = {
   DEFAULT_MODEL: ANTHROPIC_MODELS.HAIKU,
+  // Digests get a stronger model (Sonnet) regardless of the active chat model,
+  // since synthesizing 1000+ message threads benefits from the extra capability.
+  // Override via the ANTHROPIC_DIGEST_MODEL env var.
+  DIGEST_MODEL: ANTHROPIC_MODELS.SONNET,
   MAX_TOKENS: {
     CHAT: 4096,
     DIGEST: 8192,

--- a/src/utils/openAI.ts
+++ b/src/utils/openAI.ts
@@ -97,7 +97,8 @@ export async function getProjectDigestResponse(
     : '';
 
   const message = await anthropic.messages.create({
-    model: getActiveModel(),
+    // Digests use a stronger model than the active chat model (default Sonnet).
+    model: process.env.ANTHROPIC_DIGEST_MODEL || ANTHROPIC_CONFIG.DIGEST_MODEL,
     max_tokens: ANTHROPIC_CONFIG.MAX_TOKENS.DIGEST,
     system: PROJECT_DIGEST_SYSTEM_PROMPT,
     messages: [


### PR DESCRIPTION
## Summary
Digests now use **claude-sonnet-4-6** regardless of the active chat model — Sonnet is more reliable at synthesizing 1000+ message threads. Everything else (#question, weekly pulse) keeps using the active model (Haiku default, switchable via /model).

- `ANTHROPIC_CONFIG.DIGEST_MODEL = Sonnet`; `getProjectDigestResponse` uses it (env override: `ANTHROPIC_DIGEST_MODEL`).

## Test plan
- [x] typecheck / format:check / build clean
- [x] Verified: digest call runs on Sonnet; getActiveModel() (chat) still Haiku