### PR TITLE
feat: /voice command — voice-channel transcription with Conduit ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ exports/
 # PouchDB local stores (runtime)
 attendees_db/
 settings_db/
+
+# Voice session artifacts (large, local-only)
+audio/
+exports/

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -120,3 +120,12 @@
 1. Opponent - **OPTIONAL**
 
 ### `/standup` - Provide standup update
+
+### `/voice` - Otter.ai style: join voice channel for transcription & recording (ingests to Conduit)
+
+**Actions** (required):
+
+- `join` [channel] : Bot joins (defaults to CHECKINS or VIRTUAL_OFFICE env), starts listening for speakers.
+- `stop` : Leaves VC, produces transcript stub + metadata, saves locally to exports/voice/, ingests to conduit.source_documents (via Supabase if configured).
+
+**Status**: Initial implementation (speaking events captured; full live audio->STT via whisper-live-server or OpenAI pending for real text). Context (channel, participants, times) captured for conduit ingestion.

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  apps: [
+    {
+      name: 'gitfitbot',
+      script: './dist/src/index.js',
+      // Start pm2 while the correct Node is active in your shell (nvm use 22).
+      // Or force it: pm2 start ecosystem.config.js --interpreter $(which node)
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "GNU GPLv3",
   "dependencies": {
     "@anthropic-ai/sdk": "latest",
+    "@discordjs/opus": "latest",
+    "@discordjs/voice": "latest",
     "@notionhq/client": "latest",
     "@supabase/supabase-js": "latest",
     "@types/pg": "^8.20.0",
@@ -27,16 +29,22 @@
     "discord-tictactoe": "latest",
     "discord.js": "latest",
     "dotenv": "latest",
+    "ffmpeg-static": "latest",
+    "libsodium-wrappers": "latest",
     "newrelic": "latest",
+    "opusscript": "^0.1.1",
     "pg": "^8.22.0",
     "pouchdb-node": "latest",
-    "undici": "latest"
+    "prism-media": "latest",
+    "undici": "latest",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
     "@types/node": "latest",
     "@types/pouchdb-node": "latest",
+    "@types/ws": "^8.18.1",
     "husky": "latest",
     "lint-staged": "latest",
     "prettier": "latest",
@@ -58,7 +66,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "leveldown"
+      "leveldown",
+      "@discordjs/opus",
+      "ffmpeg-static"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@anthropic-ai/sdk':
         specifier: latest
         version: 0.106.0(zod@3.25.28)
+      '@discordjs/opus':
+        specifier: latest
+        version: 0.10.0(encoding@0.1.13)
+      '@discordjs/voice':
+        specifier: latest
+        version: 0.19.2(@discordjs/opus@0.10.0(encoding@0.1.13))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(ffmpeg-static@5.3.0)(opusscript@0.1.1)
       '@notionhq/client':
         specifier: latest
         version: 3.1.2
@@ -35,18 +41,33 @@ importers:
       dotenv:
         specifier: latest
         version: 16.5.0
+      ffmpeg-static:
+        specifier: latest
+        version: 5.3.0
+      libsodium-wrappers:
+        specifier: latest
+        version: 0.8.4
       newrelic:
         specifier: latest
         version: 12.19.0
+      opusscript:
+        specifier: ^0.1.1
+        version: 0.1.1
       pg:
         specifier: ^8.22.0
         version: 8.22.0
       pouchdb-node:
         specifier: latest
         version: 9.0.0(encoding@0.1.13)
+      prism-media:
+        specifier: latest
+        version: 1.3.5(@discordjs/opus@0.10.0(encoding@0.1.13))(ffmpeg-static@5.3.0)(opusscript@0.1.1)
       undici:
         specifier: latest
         version: 7.10.0
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
       '@commitlint/cli':
         specifier: latest
@@ -60,6 +81,9 @@ importers:
       '@types/pouchdb-node':
         specifier: latest
         version: 6.1.7
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       husky:
         specifier: latest
         version: 9.1.7
@@ -186,6 +210,10 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@derhuerst/http-basic@8.2.4':
+    resolution: {integrity: sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==}
+    engines: {node: '>=6.0.0'}
+
   '@discordjs/builders@1.11.2':
     resolution: {integrity: sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==}
     engines: {node: '>=16.11.0'}
@@ -202,6 +230,14 @@ packages:
     resolution: {integrity: sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==}
     engines: {node: '>=16.11.0'}
 
+  '@discordjs/node-pre-gyp@0.4.5':
+    resolution: {integrity: sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==}
+    hasBin: true
+
+  '@discordjs/opus@0.10.0':
+    resolution: {integrity: sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==}
+    engines: {node: '>=12.0.0'}
+
   '@discordjs/rest@2.5.0':
     resolution: {integrity: sha512-PWhchxTzpn9EV3vvPRpwS0EE2rNYB9pvzDU/eLLW3mByJl0ZHZjHI2/wA8EbH2gRMQV7nu+0FoDF84oiPl8VAQ==}
     engines: {node: '>=18'}
@@ -210,9 +246,22 @@ packages:
     resolution: {integrity: sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==}
     engines: {node: '>=18'}
 
+  '@discordjs/voice@0.19.2':
+    resolution: {integrity: sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==}
+    engines: {node: '>=22.12.0'}
+
   '@discordjs/ws@1.2.2':
     resolution: {integrity: sha512-dyfq7yn0wO0IYeYOs3z79I6/HumhmKISzFL0Z+007zQJMtAFGtt3AEoq1nuLXtcunUE5YYYQqgKvybXukAK8/w==}
     engines: {node: '>=16.11.0'}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
@@ -235,6 +284,12 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@newrelic/native-metrics@11.1.0':
     resolution: {integrity: sha512-V+FRgRgv6R8LAnVsix8d1bL5SMmBONURaT/6F//rOgycvU7PfPoVEocacpSRzPFxMI27e46iAf3W5fGosbQ8yQ==}
@@ -319,6 +374,97 @@ packages:
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
+  '@snazzah/davey-android-arm-eabi@0.1.12':
+    resolution: {integrity: sha512-6VC/an+Sx5dI5skb+90rYcIB1jhm48Rl0nDaw0UNT4bz1rMjpVfmmZqeocYXMq96IdbBMlE6OTKGcBm2C3gkQg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@snazzah/davey-android-arm64@0.1.12':
+    resolution: {integrity: sha512-0Bwd03/JsTFhlPhF4q/LW0RxSzntFpQdhz+TBdFljYSg8IEyA38saPJeTNjpIgDfhAumPzvhCdfS6O5qT8yXDw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@snazzah/davey-darwin-arm64@0.1.12':
+    resolution: {integrity: sha512-lKMV6ITi9BQLt0fx/pAT7M8xcojVK7bryVJGdaW3bq8gABFslS3ti/KzrWabQvhpEV71FZe5mV0UcKHFVaTsZw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@snazzah/davey-darwin-x64@0.1.12':
+    resolution: {integrity: sha512-vXXc/eW/e3TQeb7VsdtrPqs3/22j0aSqiP1ZXmZtDjQRBwgSxwItWYa6sh5MELP2EHB2igNlGzB6Hc0XlbGi4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@snazzah/davey-freebsd-x64@0.1.12':
+    resolution: {integrity: sha512-G1gas5HrC4Xp3mRY0+OeAqXS6fG2tRgBEc8gQh69Hw4YK9RV9mzQKcmoKMkBM72U1+2C+2u57dolnKKzwozByQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@snazzah/davey-linux-arm-gnueabihf@0.1.12':
+    resolution: {integrity: sha512-97Fujh82r2Ll7dPZeNuoZ3yKfsqycf3c93OWXOo/ThNL/18Onl2Ht4SIvpX6VHhfeS9bDpHJ1lHCaz1b/i5ocw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@snazzah/davey-linux-arm64-gnu@0.1.12':
+    resolution: {integrity: sha512-FWyAOv52cHKDM4BOsmImKKogHFvqNFoXmZcicNJbX3XpVl8Mas88ZoXQ+IA5V+qc9pNtAl1MbWwEZ9JrqAQtbg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@snazzah/davey-linux-arm64-musl@0.1.12':
+    resolution: {integrity: sha512-ptRbLSQxtV6EjXppS5z7qaPDI0NRKhrkJYsTlAjEghmOvlAObozSCYYnMO6nbkt6Ab3+lWqyahClzcRNcD2ouw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@snazzah/davey-linux-x64-gnu@0.1.12':
+    resolution: {integrity: sha512-w86fZvhJn0ErOoAQHt2UbQ95V/cgwvfvQ4GlTPQLCzt58nn+rLlXLgPn90qYlSQrZxFW38rKXwqVOMbm9p+pwQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@snazzah/davey-linux-x64-musl@0.1.12':
+    resolution: {integrity: sha512-LLNnO+hfG41ymeI+O1YHo5/0h3aKaetUNLdkBwpdJsjoyKMXZaeCnB+aHNkkupJCMPmWS0g6iPMCHUOqZSBcTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@snazzah/davey-wasm32-wasi@0.1.12':
+    resolution: {integrity: sha512-MPKFuqYVkDFXheR7qmtEY4FWxQ/ADfgsCojQWHi13sibUqCTR9q2F1LqNn2i9IVh3sh1sxeg87fdFMCH63pl7g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@snazzah/davey-win32-arm64-msvc@0.1.12':
+    resolution: {integrity: sha512-Uf4OYHyfbXpzyaOqIV8/h6kv166Qni5+Bxmc1E/ov4uhhKO8qXbOky8zbVOzu0U4cv5ll3s4IQ8jDAJkx/K75Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@snazzah/davey-win32-ia32-msvc@0.1.12':
+    resolution: {integrity: sha512-nRVbKTsb2ldcPI8D4BDA7P/UeiMEMvR+wYuUMp7H1pRD/3dF2hKo+MzUU+Pn78EhuYA3CWHItiAcS/GsPld67A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@snazzah/davey-win32-x64-msvc@0.1.12':
+    resolution: {integrity: sha512-AgUA3itPDVkxQq7RIkgE1thCiWePwWjyfOZefBBxGIlMWpRUOSwF4vY9kNLnrScyJcFULdR+Zm8PwiwV8/RKnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@snazzah/davey@0.1.12':
+    resolution: {integrity: sha512-V+NlX5931RwVamZhhEfZekMdcvXDKdMAmHW1AuGaykVQsNyBOq3bpmGpoKRBDCYgFWKIufJ0Dcg3m4cYhvUy6g==}
+    engines: {node: '>= 10'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -355,6 +501,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/concat-stream@1.6.1':
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
@@ -436,6 +585,9 @@ packages:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abstract-leveldown@6.2.3:
     resolution: {integrity: sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==}
     engines: {node: '>=6'}
@@ -465,6 +617,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -492,6 +648,14 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -510,6 +674,9 @@ packages:
   axios@1.9.0:
     resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -518,6 +685,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -562,6 +732,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -584,6 +758,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -598,6 +776,9 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
@@ -605,6 +786,9 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -682,9 +866,19 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  discord-api-types@0.38.49:
+    resolution: {integrity: sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==}
 
   discord-api-types@0.38.8:
     resolution: {integrity: sha512-xuRXPD44FcbKHrQK15FS1HFlMRNJtsaZou/SVws18vQ7zHqmlxyDktMkZpyvD6gE2ctGOVYC/jUyoMMAyBWfcw==}
@@ -793,6 +987,10 @@ packages:
   fetch-cookie@2.2.0:
     resolution: {integrity: sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==}
 
+  ffmpeg-static@5.3.0:
+    resolution: {integrity: sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==}
+    engines: {node: '>=16'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -831,8 +1029,20 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -859,6 +1069,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -878,6 +1092,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
@@ -894,6 +1111,10 @@ packages:
 
   http-response-object@3.0.2:
     resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -923,6 +1144,10 @@ packages:
 
   import-meta-resolve@4.1.0:
     resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1080,6 +1305,12 @@ packages:
     engines: {node: '>=6'}
     deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
 
+  libsodium-wrappers@0.8.4:
+    resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
+
+  libsodium@0.8.4:
+    resolution: {integrity: sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -1159,6 +1390,10 @@ packages:
   magic-bytes.js@1.12.1:
     resolution: {integrity: sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==}
 
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -1189,11 +1424,31 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -1220,6 +1475,10 @@ packages:
     resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
     engines: {node: '>=10'}
 
+  node-addon-api@8.9.0:
+    resolution: {integrity: sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-fetch@2.6.9:
     resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
     engines: {node: 4.x || >=6.0.0}
@@ -1237,9 +1496,22 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   npm-run-path@3.1.0:
     resolution: {integrity: sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==}
     engines: {node: '>=8'}
+
+  npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1251,6 +1523,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  opusscript@0.1.1:
+    resolution: {integrity: sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==}
 
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
@@ -1274,6 +1549,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1370,8 +1649,29 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  prism-media@1.3.5:
+    resolution: {integrity: sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==}
+    peerDependencies:
+      '@discordjs/opus': '>=0.8.0 <1.0.0'
+      ffmpeg-static: ^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0
+      node-opus: ^0.3.3
+      opusscript: ^0.0.8
+    peerDependenciesMeta:
+      '@discordjs/opus':
+        optional: true
+      ffmpeg-static:
+        optional: true
+      node-opus:
+        optional: true
+      opusscript:
+        optional: true
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
@@ -1457,6 +1757,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   ringbufferjs@2.0.0:
     resolution: {integrity: sha512-GCOqTzUsTHF7nrqcgtNGAFotXztLgiePpIDpyWZ7R5I02tmfJWV+/yuJc//Hlsd8G+WzI1t/dc2y/w2imDZdog==}
 
@@ -1473,10 +1778,17 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -1496,6 +1808,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -1569,6 +1884,11 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
@@ -1692,6 +2012,9 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
@@ -1710,8 +2033,8 @@ packages:
   write-stream@0.4.3:
     resolution: {integrity: sha512-IJrvkhbAnj89W/GAVdVgbnPiVw5Ntg/B4tc/MUCIEwj/g6JIww1DWJyB/yBMT3yw2/TkT6IUZ0+IYef3flEw8A==}
 
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1729,6 +2052,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.0:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
@@ -1895,6 +2221,13 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@derhuerst/http-basic@8.2.4':
+    dependencies:
+      caseless: 0.12.0
+      concat-stream: 2.0.0
+      http-response-object: 3.0.2
+      parse-cache-control: 1.0.1
+
   '@discordjs/builders@1.11.2':
     dependencies:
       '@discordjs/formatters': 0.6.1
@@ -1913,6 +2246,29 @@ snapshots:
     dependencies:
       discord-api-types: 0.38.8
 
+  '@discordjs/node-pre-gyp@0.4.5(encoding@0.1.13)':
+    dependencies:
+      detect-libc: 2.1.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.6.9(encoding@0.1.13)
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.7.2
+      tar: 6.2.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@discordjs/opus@0.10.0(encoding@0.1.13)':
+    dependencies:
+      '@discordjs/node-pre-gyp': 0.4.5(encoding@0.1.13)
+      node-addon-api: 8.9.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@discordjs/rest@2.5.0':
     dependencies:
       '@discordjs/collection': 2.1.1
@@ -1927,6 +2283,24 @@ snapshots:
 
   '@discordjs/util@1.1.1': {}
 
+  '@discordjs/voice@0.19.2(@discordjs/opus@0.10.0(encoding@0.1.13))(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(ffmpeg-static@5.3.0)(opusscript@0.1.1)':
+    dependencies:
+      '@snazzah/davey': 0.1.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@types/ws': 8.18.1
+      discord-api-types: 0.38.49
+      prism-media: 1.3.5(@discordjs/opus@0.10.0(encoding@0.1.13))(ffmpeg-static@5.3.0)(opusscript@0.1.1)
+      tslib: 2.8.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - bufferutil
+      - ffmpeg-static
+      - node-opus
+      - opusscript
+      - utf-8-validate
+
   '@discordjs/ws@1.2.2':
     dependencies:
       '@discordjs/collection': 2.1.1
@@ -1937,10 +2311,26 @@ snapshots:
       '@vladfrangu/async_event_emitter': 2.4.6
       discord-api-types: 0.38.8
       tslib: 2.8.1
-      ws: 8.18.2
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@grpc/grpc-js@1.13.4':
     dependencies:
@@ -1964,6 +2354,13 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
 
   '@newrelic/native-metrics@11.1.0':
     dependencies:
@@ -1996,7 +2393,7 @@ snapshots:
       unescape: 1.0.1
       unescape-js: 1.1.4
       uuid: 9.0.1
-      ws: 8.18.2
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -2062,6 +2459,73 @@ snapshots:
 
   '@sapphire/snowflake@3.5.3': {}
 
+  '@snazzah/davey-android-arm-eabi@0.1.12':
+    optional: true
+
+  '@snazzah/davey-android-arm64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-darwin-arm64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-darwin-x64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-freebsd-x64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-arm-gnueabihf@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-arm64-gnu@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-arm64-musl@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-x64-gnu@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-x64-musl@0.1.12':
+    optional: true
+
+  '@snazzah/davey-wasm32-wasi@0.1.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@snazzah/davey-win32-arm64-msvc@0.1.12':
+    optional: true
+
+  '@snazzah/davey-win32-ia32-msvc@0.1.12':
+    optional: true
+
+  '@snazzah/davey-win32-x64-msvc@0.1.12':
+    optional: true
+
+  '@snazzah/davey@0.1.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    optionalDependencies:
+      '@snazzah/davey-android-arm-eabi': 0.1.12
+      '@snazzah/davey-android-arm64': 0.1.12
+      '@snazzah/davey-darwin-arm64': 0.1.12
+      '@snazzah/davey-darwin-x64': 0.1.12
+      '@snazzah/davey-freebsd-x64': 0.1.12
+      '@snazzah/davey-linux-arm-gnueabihf': 0.1.12
+      '@snazzah/davey-linux-arm64-gnu': 0.1.12
+      '@snazzah/davey-linux-arm64-musl': 0.1.12
+      '@snazzah/davey-linux-x64-gnu': 0.1.12
+      '@snazzah/davey-linux-x64-musl': 0.1.12
+      '@snazzah/davey-wasm32-wasi': 0.1.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@snazzah/davey-win32-arm64-msvc': 0.1.12
+      '@snazzah/davey-win32-ia32-msvc': 0.1.12
+      '@snazzah/davey-win32-x64-msvc': 0.1.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   '@stablelib/base64@1.0.1': {}
 
   '@supabase/auth-js@2.69.1':
@@ -2085,7 +2549,7 @@ snapshots:
       '@supabase/node-fetch': 2.6.15
       '@types/phoenix': 1.6.6
       '@types/ws': 8.18.1
-      ws: 8.18.2
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -2113,6 +2577,11 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/concat-stream@1.6.1':
     dependencies:
@@ -2196,7 +2665,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.15.21
+      '@types/node': 26.0.1
 
   '@tyriar/fibonacci-heap@2.0.9': {}
 
@@ -2206,6 +2675,8 @@ snapshots:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
+
+  abbrev@1.1.1: {}
 
   abstract-leveldown@6.2.3:
     dependencies:
@@ -2242,6 +2713,12 @@ snapshots:
 
   acorn@8.14.1: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.3: {}
 
   ajv@8.17.1:
@@ -2265,6 +2742,13 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  aproba@2.1.0: {}
+
+  are-we-there-yet@2.0.0:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+
   arg@4.1.3: {}
 
   argparse@2.0.1: {}
@@ -2283,6 +2767,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   bignumber.js@9.3.0: {}
@@ -2293,6 +2779,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   braces@3.0.3:
     dependencies:
@@ -2333,6 +2824,8 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
+  chownr@2.0.0: {}
+
   cjs-module-lexer@1.4.3: {}
 
   cli-cursor@5.0.0:
@@ -2356,6 +2849,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-support@1.1.3: {}
+
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -2368,6 +2863,8 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
+
+  concat-map@0.0.1: {}
 
   concat-stream@1.6.2:
     dependencies:
@@ -2382,6 +2879,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
+
+  console-control-strings@1.1.0: {}
 
   content-type@1.0.5: {}
 
@@ -2447,7 +2946,13 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  delegates@1.0.0: {}
+
+  detect-libc@2.1.2: {}
+
   diff@4.0.2: {}
+
+  discord-api-types@0.38.49: {}
 
   discord-api-types@0.38.8: {}
 
@@ -2566,6 +3071,15 @@ snapshots:
       set-cookie-parser: 2.7.1
       tough-cookie: 4.1.4
 
+  ffmpeg-static@5.3.0:
+    dependencies:
+      '@derhuerst/http-basic': 8.2.4
+      env-paths: 2.2.1
+      https-proxy-agent: 5.0.1
+      progress: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -2606,7 +3120,25 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0: {}
+
   function-bind@1.1.2: {}
+
+  gauge@3.0.2:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
 
   get-caller-file@2.0.5: {}
 
@@ -2638,6 +3170,15 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -2651,6 +3192,8 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  has-unicode@2.0.1: {}
 
   hash.js@1.1.7:
     dependencies:
@@ -2673,6 +3216,13 @@ snapshots:
   http-response-object@3.0.2:
     dependencies:
       '@types/node': 10.17.60
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -2705,6 +3255,11 @@ snapshots:
       module-details-from-path: 1.0.4
 
   import-meta-resolve@4.1.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -2841,6 +3396,12 @@ snapshots:
       level-supports: 1.0.1
       xtend: 4.0.2
 
+  libsodium-wrappers@0.8.4:
+    dependencies:
+      libsodium: 0.8.4
+
+  libsodium@0.8.4: {}
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -2930,6 +3491,10 @@ snapshots:
 
   magic-bytes.js@1.12.1: {}
 
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
   make-error@1.3.6: {}
 
   math-intrinsics@1.1.0: {}
@@ -2951,10 +3516,27 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
   minimist@1.2.8: {}
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
 
   mkdirp-classic@0.5.3:
     optional: true
+
+  mkdirp@1.0.4: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -3001,6 +3583,8 @@ snapshots:
       semver: 7.7.2
     optional: true
 
+  node-addon-api@8.9.0: {}
+
   node-fetch@2.6.9(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -3011,21 +3595,35 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+
   npm-run-path@3.1.0:
     dependencies:
       path-key: 3.1.1
     optional: true
+
+  npmlog@5.0.1:
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  opusscript@0.1.1: {}
 
   p-limit@4.0.0:
     dependencies:
@@ -3049,6 +3647,8 @@ snapshots:
       lines-and-columns: 1.2.4
 
   path-exists@5.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1:
     optional: true
@@ -3143,7 +3743,15 @@ snapshots:
 
   pretty-bytes@5.6.0: {}
 
+  prism-media@1.3.5(@discordjs/opus@0.10.0(encoding@0.1.13))(ffmpeg-static@5.3.0)(opusscript@0.1.1):
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0(encoding@0.1.13)
+      ffmpeg-static: 5.3.0
+      opusscript: 0.1.1
+
   process-nextick-args@2.0.1: {}
+
+  progress@2.0.3: {}
 
   promise@8.3.0:
     dependencies:
@@ -3246,6 +3854,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
   ringbufferjs@2.0.0: {}
 
   safe-buffer@5.1.2: {}
@@ -3257,7 +3869,11 @@ snapshots:
   safer-buffer@2.1.2:
     optional: true
 
+  semver@6.3.1: {}
+
   semver@7.7.2: {}
+
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.1: {}
 
@@ -3288,6 +3904,8 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -3378,6 +3996,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   text-extensions@2.4.0: {}
 
@@ -3491,6 +4118,10 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+
   winston-transport@4.9.0:
     dependencies:
       logform: 2.7.0
@@ -3509,18 +4140,19 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.0
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   write-stream@0.4.3:
     dependencies:
       readable-stream: 0.0.4
 
-  ws@8.18.2: {}
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.0: {}
 

--- a/run-with-node22.sh
+++ b/run-with-node22.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+echo "=== Activating Node 22 ==="
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm use 22
+
+echo "=== Current versions ==="
+node --version
+pnpm --version
+
+echo "=== Checking .env ==="
+if grep -q "DISCORD_BOT_TOKEN=$" .env; then
+  echo "WARNING: .env has blank DISCORD_BOT_TOKEN. Bot will fail to login."
+  echo "Populate from Keybase (team gitfitcode > discord bot secrets > autobot > .env)"
+fi
+
+echo "=== Launching with pm2 ==="
+pm2 start ecosystem.config.js --interpreter $(which node)
+echo ""
+echo "Use these commands:"
+echo "  pm2 logs gitfitbot"
+echo "  pm2 restart gitfitbot"
+echo "  pm2 stop gitfitbot"

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -16,6 +16,7 @@ import Standup from './commands/Standup';
 import Support from './commands/Support';
 import Test from './commands/Test';
 import TicTacToe from './commands/TicTacToe';
+import Voice from './commands/Voice';
 
 const Commands: SlashCommand[] = [
   Backlog,
@@ -31,6 +32,7 @@ const Commands: SlashCommand[] = [
   Support,
   Test,
   TicTacToe,
+  Voice,
 ];
 
 export default Commands;

--- a/src/commands/Voice.ts
+++ b/src/commands/Voice.ts
@@ -1,0 +1,985 @@
+/**
+ * Slash command for Otter.ai-like experience in Discord.
+ * Bot joins a voice channel, transcribes (using OpenAI Whisper or prepared for whisper-live-server),
+ * records audio, and ingests full context + transcript into conduit.
+ */
+
+import {
+  EndBehaviorType,
+  entersState,
+  joinVoiceChannel,
+  VoiceConnection,
+  VoiceConnectionStatus,
+} from '@discordjs/voice';
+import { spawn } from 'child_process';
+import {
+  ApplicationCommandOptionType,
+  ChannelType,
+  Client,
+  CommandInteraction,
+  GuildMember,
+  VoiceBasedChannel,
+} from 'discord.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as prism from 'prism-media';
+import { request } from 'undici';
+import { SlashCommand } from '../Command';
+import { COMMAND_VOICE } from '../utils/constants';
+
+const ffmpegPath: string = require('ffmpeg-static');
+
+interface VoiceSession {
+  connection: VoiceConnection;
+  client: Client;
+  guildId: string;
+  channelId: string;
+  channelName: string;
+  startedAt: Date;
+  speakingEvents: Array<{ userId: string; username: string; started: Date; ended?: Date }>;
+  transcripts: string[];
+  audioPaths: string[];
+  transcriptThread?: any; // Discord ThreadChannel for the live convo
+  startMessage?: any; // The initial "GitFitBot joined..." announcement message.
+  allLiveMessage?: any; // The "All live segments..." message. Live captions will reply to this to be "within a reply".
+  localTranscriptions: number;
+  openaiTranscriptions: number;
+  estimatedAudioSeconds: number; // rough, for cost awareness
+}
+
+const activeSessions: Map<string, VoiceSession> = new Map();
+
+async function getVoiceChannel(
+  interaction: CommandInteraction,
+  explicit?: string | null,
+): Promise<VoiceBasedChannel | null> {
+  const guild = interaction.guild;
+  if (!guild) return null;
+
+  if (explicit) {
+    const ch = await guild.channels.fetch(explicit).catch(() => null);
+    if (ch && ch.type === ChannelType.GuildVoice) return ch as VoiceBasedChannel;
+  }
+
+  // NEW: If the user who ran the command is currently connected to a voice channel,
+  // use that automatically. This is the nicest UX when running the command from
+  // a voice channel or while already in one.
+  const member = interaction.member as GuildMember | null;
+  const currentVoice = member?.voice?.channel;
+  if (currentVoice && currentVoice.type === ChannelType.GuildVoice) {
+    return currentVoice as VoiceBasedChannel;
+  }
+
+  // Default to env configured or first voice
+  const checkins = process.env.CHECKINS_VOICE_CHANNEL_ID;
+  if (checkins) {
+    const ch = await guild.channels.fetch(checkins).catch(() => null);
+    if (ch && ch.type === ChannelType.GuildVoice) return ch as VoiceBasedChannel;
+  }
+  const office = process.env.VIRTUAL_OFFICE_VOICE_CHANNEL_ID;
+  if (office) {
+    const ch = await guild.channels.fetch(office).catch(() => null);
+    if (ch && ch.type === ChannelType.GuildVoice) return ch as VoiceBasedChannel;
+  }
+
+  // Fallback: find any voice channel with people
+  const any = guild.channels.cache.find(
+    (c) => c.type === ChannelType.GuildVoice && (c as VoiceBasedChannel).members.size > 0,
+  ) as VoiceBasedChannel | undefined;
+  return any ?? null;
+}
+
+async function joinAndListen(
+  client: Client,
+  interaction: CommandInteraction,
+  targetChannelId?: string | null,
+) {
+  const guild = interaction.guild!;
+  const voiceChannel = await getVoiceChannel(interaction, targetChannelId);
+  if (!voiceChannel) {
+    await interaction.followUp({
+      content:
+        'No suitable voice channel found or specified. Use /voice join <channel> or set CHECKINS_VOICE_CHANNEL_ID.',
+    });
+    return;
+  }
+
+  const guildId = guild.id;
+  if (activeSessions.has(guildId)) {
+    await interaction.followUp({
+      content: `Already listening in a voice channel for this guild. Use /voice stop first.`,
+    });
+    return;
+  }
+
+  await interaction.followUp({
+    content: `Joining **${voiceChannel.name}** and starting transcription session... (Otter mode)`,
+    ephemeral: true,
+  });
+
+  const connection = joinVoiceChannel({
+    channelId: voiceChannel.id,
+    guildId: guild.id,
+    adapterCreator: guild.voiceAdapterCreator as any,
+    selfDeaf: false,
+    selfMute: true, // listen only
+  });
+
+  // Better observability for voice connection
+  connection.on(VoiceConnectionStatus.Ready, () => {
+    console.log(`[VOICE] ✅ Voice connection READY in ${voiceChannel.name}`);
+  });
+
+  connection.on('error', (error) => {
+    console.error(`[VOICE] Voice connection ERROR in ${voiceChannel.name}:`, error);
+  });
+
+  connection.on(VoiceConnectionStatus.Destroyed, () => {
+    console.log(`[VOICE] Voice connection DESTROYED for guild ${guildId}`);
+    activeSessions.delete(guildId);
+  });
+
+  // Only attempt recovery on disconnect; do NOT auto-destroy unless recovery fails badly.
+  // This prevents the bot from randomly leaving the channel.
+  connection.on(VoiceConnectionStatus.Disconnected, async () => {
+    console.warn(
+      `[VOICE] ⚠️ Voice connection DISCONNECTED in ${voiceChannel.name}. Trying to recover...`,
+    );
+    try {
+      await Promise.race([
+        entersState(connection, VoiceConnectionStatus.Signalling, 10_000),
+        entersState(connection, VoiceConnectionStatus.Connecting, 10_000),
+      ]);
+      console.log(`[VOICE] Recovered connection in ${voiceChannel.name}`);
+    } catch (error) {
+      console.error(`[VOICE] Failed to recover voice connection in ${voiceChannel.name}.`, error);
+      // Do not destroy here — let the user call /voice stop or we can add manual leave later.
+      // Leaving it allows the session to potentially continue if Discord recovers.
+    }
+  });
+
+  const session: VoiceSession = {
+    connection,
+    client,
+    guildId,
+    channelId: voiceChannel.id,
+    channelName: voiceChannel.name,
+    startedAt: new Date(),
+    speakingEvents: [],
+    transcripts: [],
+    audioPaths: [],
+    localTranscriptions: 0,
+    openaiTranscriptions: 0,
+    estimatedAudioSeconds: 0,
+  };
+  activeSessions.set(guildId, session);
+
+  // Post the announcement in the configured transcript channel (the one "it's in now").
+  // If that ID is already a thread (e.g. 1499605799947735071), use it directly as the live transcript container.
+  // Otherwise send announcement + create a dedicated sub-thread for the convo.
+  const announceId = process.env.VOICE_TRANSCRIPT_CHANNEL_ID || process.env.GENERAL_CHAT_CHANNEL_ID;
+  console.log(`[VOICE] Announcement channel ID from env: ${announceId}`);
+  if (announceId && client) {
+    try {
+      const ch: any = await client.channels.fetch(announceId).catch((e: any) => {
+        console.warn('Fetch announce ch failed:', e);
+        return null;
+      });
+      console.log(`[VOICE] Fetched announce channel: ${ch ? ch.id + ' type:' + ch.type : 'null'}`);
+      if (ch && 'send' in ch && ch.type !== ChannelType.GuildVoice) {
+        const isAlreadyThread =
+          ch.type === ChannelType.GuildPublicThread ||
+          ch.type === ChannelType.GuildPrivateThread ||
+          (typeof ch.isThread === 'function' && ch.isThread());
+        const startMsg = await ch
+          .send(
+            `🎙️ **GitFitBot joined \`${voiceChannel.name}\`** and is now transcribing + recording.\n` +
+              `Started by <@${interaction.user.id}>. Run \`/voice stop\` when finished to save & ingest to Conduit.\n` +
+              `Live transcript will be in this thread.`,
+          )
+          .catch((e: any) => {
+            console.warn('Send startMsg failed:', e);
+            return null;
+          });
+
+        if (startMsg) {
+          session.startMessage = startMsg;
+
+          if (isAlreadyThread) {
+            // Use the existing thread directly (can't nest threads). This satisfies "thread in the channel that its in now".
+            session.transcriptThread = ch;
+            console.log(
+              `[VOICE] Using existing thread ${ch.id} (${ch.name || 'unnamed'}) directly for live transcript segments.`,
+            );
+            // Post the helper note as a normal message right after the joined announcement in the thread.
+            // All live voice segments will then appear sequentially in this thread (Discord doesn't have Slack-style nested sub-threads; replies give visual nesting but linear posting in the thread is cleaner here).
+            const allLiveMsg = await ch
+              .send(`All live segments for this VC session will appear here.`)
+              .catch(() => null);
+            if (allLiveMsg) session.allLiveMessage = allLiveMsg;
+          } else {
+            try {
+              const thread = await startMsg.startThread({
+                name: `Transcription - ${voiceChannel.name}`,
+                autoArchiveDuration: 1440,
+              });
+              session.transcriptThread = thread;
+              console.log(
+                `[VOICE] Created transcript thread ${thread.id} in channel ${announceId}`,
+              );
+              const allLiveMsg = await thread
+                .send(`All live segments will appear here for the full conversation.`)
+                .catch(() => null);
+              if (allLiveMsg) session.allLiveMessage = allLiveMsg;
+            } catch (threadErr) {
+              console.warn(
+                '[VOICE] Could not start thread for transcription (using announce ch as fallback):',
+                threadErr,
+              );
+              session.transcriptThread = ch;
+            }
+          }
+        }
+      }
+    } catch (e) {
+      console.warn('[VOICE] Failed to announce start:', e);
+    }
+  }
+
+  console.log(`[VOICE] Session started in guild ${guildId} channel ${voiceChannel.id}`);
+
+  const receiver = connection.receiver;
+
+  // Clean up any previous listeners to prevent accumulation on reconnects or re-joins
+  receiver.speaking.removeAllListeners('start');
+  receiver.speaking.removeAllListeners('end');
+
+  // Prevent MaxListenersExceededWarning when multiple speaking events or reconnects happen
+  (receiver.speaking as any).setMaxListeners?.(100);
+
+  receiver.speaking.on('start', (userId: string) => {
+    const member = guild.members.cache.get(userId) as GuildMember | undefined;
+    const username = member?.user?.username ?? userId;
+    console.log(`[VOICE] ${username} (${userId}) started speaking in ${voiceChannel.name}`);
+    session.speakingEvents.push({
+      userId,
+      username,
+      started: new Date(),
+    });
+
+    const audioStream = receiver.subscribe(userId, {
+      end: {
+        behavior: EndBehaviorType.AfterSilence,
+        duration: 3500, // longer to capture more complete phrases in natural conversation
+      },
+    });
+    (audioStream as any).setMaxListeners?.(100);
+
+    const audioDir = path.join(process.cwd(), 'audio');
+    fs.mkdirSync(audioDir, { recursive: true });
+    const filePath = path.join(audioDir, `${userId}-${Date.now()}.wav`);
+    session.audioPaths.push(filePath);
+
+    // Decode opus -> pcm using prism-media, then ffmpeg to wav file
+    let decoder;
+    try {
+      decoder = new prism.opus.Decoder({
+        rate: 48000,
+        channels: 2,
+        frameSize: 960,
+      });
+      (decoder as any).setMaxListeners?.(100);
+    } catch (err) {
+      console.error(`[VOICE] Failed to create opus decoder for ${username}:`, err);
+      // Still track the speaking event for metadata, but skip audio processing/transcription this time.
+      // This prevents the whole process from crashing on native module issues.
+      return;
+    }
+    const pcmStream = audioStream.pipe(decoder);
+
+    const ffmpeg = spawn(ffmpegPath, [
+      '-f',
+      's16le',
+      '-ar',
+      '48000',
+      '-ac',
+      '2',
+      '-i',
+      'pipe:0',
+      '-f',
+      'wav',
+      filePath,
+    ]);
+
+    pcmStream.pipe(ffmpeg.stdin);
+
+    ffmpeg.stderr.on('data', (d) => {
+      // uncomment for debug: console.log('ffmpeg:', d.toString());
+    });
+
+    let closeHandled = false;
+    ffmpeg.on('close', async (code) => {
+      if (closeHandled) return;
+      closeHandled = true;
+      const stats = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
+      const sizeKb = stats ? Math.round(stats.size / 1024) : 0;
+
+      console.log(
+        `[VOICE] ffmpeg closed for ${username} (code=${code}, size=${sizeKb}KB) at ${filePath}`,
+      );
+
+      // Use the stats from the close event to decide. Some closes have the file "disappear" momentarily or race with existsSync.
+      // Transcribe any file that had content at close time.
+      if (stats && sizeKb >= 15) {
+        console.log(`[VOICE] Starting transcription for ${username}...`);
+        const text = await transcribeAudio(filePath, username, session);
+        const cleaned = (text || '').trim();
+        const ts = new Date().toISOString().slice(11, 19);
+
+        // Track audio usage for cost awareness
+        const stats = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
+        if (stats && session) {
+          const audioSeconds = Math.round(stats.size / 192000); // approx for 48kHz stereo 16-bit
+          session.estimatedAudioSeconds = (session.estimatedAudioSeconds || 0) + audioSeconds;
+        }
+
+        const looksLikeWhisperJson =
+          cleaned.startsWith('{') ||
+          cleaned.includes('"text"') ||
+          cleaned.includes('"segments"') ||
+          /"language"\s*:\s*"/.test(cleaned);
+
+        // Only drop obvious non-speech / json junk from server. Be permissive so real (even short) speech shows as live segments.
+        const isGibberish = cleaned.length > 1 && cleaned.length < 30 && !/[a-zA-Z]/.test(cleaned);
+
+        const wordCount = cleaned.split(/\s+/).filter(Boolean).length;
+
+        // Detect extreme repetition only
+        const lower = cleaned.toLowerCase();
+        const hasRepetition = /\b(\w{3,})\b.*\b\1\b.*\b\1\b/.test(lower); // at least triple repeat
+
+        const isLowValue =
+          !cleaned ||
+          looksLikeWhisperJson ||
+          cleaned.includes('transcription failed') ||
+          cleaned.includes('no speech') ||
+          cleaned.includes('no usable') ||
+          cleaned.trim().length < 1;
+
+        if (!isLowValue) {
+          // Anti-repetition: skip near-duplicates of recent lines (common with Whisper on short/noisy clips)
+          const recentTexts = session.transcripts
+            .slice(-3)
+            .map((line) => line.split(': ').slice(1).join(': ').toLowerCase());
+          const norm = cleaned.toLowerCase().trim();
+          const isRepeat = recentTexts.some(
+            (prev) =>
+              prev &&
+              (norm.includes(prev) || prev.includes(norm)) &&
+              Math.abs(norm.length - prev.length) < 30,
+          );
+          if (isRepeat) {
+            console.log(
+              `[VOICE] ⚠️ Dropped near-duplicate transcription for ${username}: ${cleaned.substring(0, 60)}`,
+            );
+          } else {
+            session.transcripts.push(`[${ts}] ${username}: ${cleaned}`);
+            console.log(
+              `[VOICE] ✅ Transcribed ${username}: ${cleaned.substring(0, 80)}${cleaned.length > 80 ? '...' : ''}`,
+            );
+
+            // Live caption ONLY for useful text -> the target (thread preferred)
+            // This is the key to "live transcript in the thread"
+            if (session.client) {
+              let target: any = session.transcriptThread;
+              if (!target) {
+                const chId =
+                  process.env.VOICE_TRANSCRIPT_CHANNEL_ID ||
+                  process.env.GENERAL_CHAT_CHANNEL_ID ||
+                  '';
+                if (chId) {
+                  target = await session.client.channels.fetch(chId).catch(() => null);
+                }
+              }
+              if (target && 'send' in target) {
+                // Final safety: never post raw JSON responses or empty garbage to the thread
+                const looksLikeRaw =
+                  cleaned.startsWith('{') ||
+                  cleaned.includes('"text"') ||
+                  cleaned.includes('"segments"') ||
+                  /"language"\s*:\s*"/.test(cleaned);
+                if (looksLikeRaw || cleaned.trim().length < 1) {
+                  console.log(
+                    `[VOICE] ⚠️ Final guard blocked bad text for ${username}: ${cleaned.substring(0, 60)}`,
+                  );
+                } else {
+                  const tgtId =
+                    (session.transcriptThread && session.transcriptThread.id) ||
+                    process.env.VOICE_TRANSCRIPT_CHANNEL_ID ||
+                    process.env.GENERAL_CHAT_CHANNEL_ID;
+                  console.log(`[VOICE] Sending live caption for ${username} to ${tgtId}`);
+
+                  // Send as a normal message in the transcript thread.
+                  // Since Discord threads don't support sub-threads like Slack, this is the natural way:
+                  // all content lives linearly in the thread after the "All live segments" header.
+                  // (We previously tried replies for nesting, but given Discord's model, plain messages in the thread are cleaner and more reliable.)
+                  await target.send(`🎙️ **${username}**: ${cleaned}`).catch((e: any) => {
+                    console.warn('[VOICE] live send failed:', e?.message || e);
+                  });
+                }
+              }
+            }
+          }
+        } else {
+          console.log(
+            `[VOICE] ⚠️ Dropped low-value segment for ${username}: ${cleaned.substring(0, 60)}`,
+          );
+        }
+      } else if (sizeKb < 15) {
+        console.log(
+          `[VOICE] ⚠️ Skipping tiny clip (${sizeKb}KB < 15KB) for ${username} (too short for reliable STT)`,
+        );
+      } else {
+        console.log(
+          `[VOICE] ⚠️ Audio file for ${username} ready at ${filePath} (ffmpeg code=${code})`,
+        );
+      }
+
+      // Cleanup streams to prevent listener leaks
+      try {
+        audioStream.destroy();
+      } catch {}
+      try {
+        if (decoder && !decoder.destroyed) decoder.destroy();
+      } catch {}
+    });
+  });
+
+  receiver.speaking.on('end', (userId: string) => {
+    const evt = session.speakingEvents.findLast((e) => e.userId === userId && !e.ended);
+    if (evt) evt.ended = new Date();
+    const member = guild.members.cache.get(userId);
+    console.log(`[VOICE] ${member?.user?.username ?? userId} stopped speaking`);
+  });
+
+  // Announce in a text channel if possible (use general or a log channel)
+  // For now console + followUp already done. In prod post to GENERAL or dedicated transcript channel.
+
+  console.log(`[VOICE] Session started in guild ${guildId} channel ${voiceChannel.id}`);
+}
+
+async function stopAndIngest(interaction: CommandInteraction) {
+  const guild = interaction.guild!;
+  const session = activeSessions.get(guild.id);
+  if (!session) {
+    await interaction.followUp({
+      content: 'No active voice transcription session for this guild.',
+    });
+    return;
+  }
+
+  const { connection, channelName, startedAt, speakingEvents } = session;
+
+  connection.destroy();
+  activeSessions.delete(guild.id);
+
+  const endedAt = new Date();
+  const durationMin = Math.round((endedAt.getTime() - startedAt.getTime()) / 60000);
+
+  // Build transcript from actual captured + transcribed audio when available
+  const participants = [...new Set(speakingEvents.map((e) => e.username))];
+  const eventsSummary = speakingEvents
+    .map((e) => {
+      const dur = e.ended ? Math.round((e.ended.getTime() - e.started.getTime()) / 1000) : '?';
+      return `- ${e.username}: spoke ~${dur}s starting ${e.started.toISOString()}`;
+    })
+    .join('\n');
+
+  // Improved formatting + basic categorization: group consecutive lines from same speaker
+  let realTranscripts = 'No transcribed segments (check OPENAI_API_KEY or audio files in ./audio)';
+  if (session.transcripts && session.transcripts.length > 0) {
+    const grouped: Array<{ speaker: string; lines: string[] }> = [];
+    let currSpeaker = '';
+    let currLines: string[] = [];
+    for (const line of session.transcripts) {
+      // lines are like "[timestamp] Speaker: text" or "[Speaker] text"
+      const m = line.match(/^\[.*?\]?\s*(.+?):\s*(.*)$/);
+      const speaker = m && m[1] ? m[1].trim() : 'Unknown';
+      const content = m && m[2] !== undefined ? m[2].trim() : line;
+      if (speaker !== currSpeaker) {
+        if (currSpeaker) grouped.push({ speaker: currSpeaker, lines: currLines });
+        currSpeaker = speaker;
+        currLines = [];
+      }
+      currLines.push(content);
+    }
+    if (currSpeaker) grouped.push({ speaker: currSpeaker, lines: currLines });
+    realTranscripts = grouped.map((g) => `**${g.speaker}:**\n${g.lines.join('\n')}`).join('\n\n');
+  }
+
+  const localCount = session.localTranscriptions || 0;
+  const openaiCount = session.openaiTranscriptions || 0;
+  const totalSeconds = session.estimatedAudioSeconds || 0;
+  const roughCost = (openaiCount * 0.006).toFixed(4); // very rough, since OpenAI Whisper ~$0.006/min
+
+  const transcriptStub =
+    `# Voice Session Transcript (GitFitBot → Conduit)\n\n` +
+    `**Channel**: ${channelName}\n` +
+    `**Started**: ${startedAt.toISOString()}\n` +
+    `**Ended**: ${endedAt.toISOString()}\n` +
+    `**Duration**: ~${durationMin} min\n` +
+    `**Participants**: ${participants.join(', ') || 'none detected'}\n\n` +
+    `## Usage & Cost (for visibility)\n` +
+    `- Local transcriptions: ${localCount}\n` +
+    `- OpenAI Whisper calls: ${openaiCount}\n` +
+    `- Estimated audio processed: ~${Math.round(totalSeconds)}s\n` +
+    `- Rough OpenAI cost (if any): $${roughCost} (only counts OpenAI path)\n\n` +
+    `## Transcribed conversation\n${realTranscripts}\n\n` +
+    `## Raw speaking events\n${eventsSummary || 'No events'}\n\n` +
+    `**Audio files**: ${session.audioPaths?.join(', ') || 'none'}\n` +
+    `**Note**: Audio was recorded per utterance. Prefer local Whisper to avoid costs. Local errors fall back to OpenAI.\n`;
+
+  // TODO: full audio recording + STT here. For now, use this stub + metadata.
+
+  // Ingest to conduit (best effort using Supabase if configured, else local export)
+  const ingestResult = await ingestToConduit({
+    title: `Discord VC: ${channelName} @ ${startedAt.toISOString().slice(0, 16)}`,
+    body: transcriptStub,
+    source_type: 'discord_voice_transcript',
+    metadata: {
+      guild_id: guild.id,
+      channel_id: session.channelId,
+      channel_name: channelName,
+      started_at: startedAt,
+      ended_at: endedAt,
+      participants,
+      event_count: speakingEvents.length,
+      bot: 'gitfitbot',
+      version: 'voice-v0.1',
+    },
+  });
+
+  // Also dump to local for review (like other digests)
+  const fs = await import('fs/promises');
+  const path = await import('path');
+  const exportDir = path.join(process.cwd(), 'exports', 'voice');
+  await fs.mkdir(exportDir, { recursive: true });
+  const slug = `${channelName.replace(/\s+/g, '-')}-${startedAt.toISOString().slice(0, 16).replace(/[:T]/g, '-')}`;
+  const filePath = path.join(exportDir, `${slug}.md`);
+  await fs.writeFile(filePath, transcriptStub, 'utf8');
+
+  const summary =
+    `**Session ended.** Duration ~${durationMin}m. ` +
+    `Transcript stub saved to ${filePath}. Ingest status: ${ingestResult.ok ? 'OK (doc ID: ' + (ingestResult.id ?? 'unknown') + ')' : 'logged (no full conduit yet)'}.\n\n` +
+    `Usage: ${localCount} local + ${openaiCount} OpenAI transcriptions (~${Math.round(totalSeconds)}s audio). Rough OpenAI cost ~$${roughCost}.\n` +
+    `Audio files: ${session.audioPaths?.join(', ') || 'none'}`;
+
+  await interaction.followUp({ content: summary });
+
+  // Post summary to the session thread if exists (for the full convo), else to transcript channel
+  let summaryTarget: any = session.transcriptThread;
+  if (!summaryTarget) {
+    const annId = process.env.VOICE_TRANSCRIPT_CHANNEL_ID || process.env.GENERAL_CHAT_CHANNEL_ID;
+    if (annId && session.client) {
+      summaryTarget = await session.client.channels.fetch(annId).catch(() => null);
+    }
+  }
+  if (summaryTarget && 'send' in summaryTarget) {
+    const summaryContent =
+      `✅ **Transcription session in \`${channelName}\` ended.**\n` +
+      `Duration: ~${durationMin}m | Segments: ${session.transcripts?.length || 0}\n` +
+      `Usage: ${localCount} local + ${openaiCount} OpenAI (~${Math.round(totalSeconds)}s). Rough OpenAI cost ~$${roughCost}.\n` +
+      `${ingestResult.ok ? '✅ Ingested to Conduit (doc ID logged in bot)' : '⚠️ Ingest may have failed — check logs'}\n` +
+      `Full transcript saved locally too.`;
+    const refId = session.startMessage?.id;
+    const payload: any = { content: summaryContent };
+    if (refId) {
+      payload.messageReference = { messageId: refId };
+    }
+    await summaryTarget.send(payload).catch(() => {});
+  }
+
+  console.log(`[VOICE] Session fully ended for guild ${guild.id}. Ingest result:`, ingestResult);
+}
+
+async function showStatus(interaction: CommandInteraction) {
+  const guild = interaction.guild!;
+  const session = activeSessions.get(guild.id);
+
+  let content = 'No active voice transcription session for this guild.';
+  if (session) {
+    const durationMin = Math.round((Date.now() - session.startedAt.getTime()) / 60000);
+    const segs = session.transcripts?.length || 0;
+    const files = session.audioPaths?.length || 0;
+    content =
+      `**Active session in ${session.channelName}**\n` +
+      `Started: ${session.startedAt.toISOString()} (~${durationMin}m ago)\n` +
+      `Segments transcribed: ${segs}\n` +
+      `Audio files captured: ${files}\n` +
+      `Local transcriptions: ${session.localTranscriptions || 0} | OpenAI: ${session.openaiTranscriptions || 0}\n` +
+      `Est. audio: ~${Math.round(session.estimatedAudioSeconds || 0)}s\n` +
+      `Use \`/voice stop\` to end and ingest to Conduit, or \`/voice leave\` to force disconnect.`;
+  }
+
+  await interaction.followUp({ content, ephemeral: true });
+}
+
+async function forceLeave(interaction: CommandInteraction) {
+  const guild = interaction.guild!;
+  const session = activeSessions.get(guild.id);
+
+  if (!session) {
+    await interaction.followUp({
+      content: 'No active voice transcription session for this guild.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  try {
+    session.connection.destroy();
+  } catch (e) {
+    console.warn('[VOICE] Error during force leave destroy:', e);
+  }
+  activeSessions.delete(guild.id);
+
+  await interaction.followUp({
+    content: `Force left voice channel ${session.channelName}. Session cleared (no ingest performed).`,
+  });
+
+  // Also announce
+  const announceId = process.env.VOICE_TRANSCRIPT_CHANNEL_ID || process.env.GENERAL_CHAT_CHANNEL_ID;
+  if (announceId && session.client) {
+    try {
+      const ch = await session.client.channels.fetch(announceId).catch(() => null);
+      if (ch && 'send' in ch && (ch as any).type !== ChannelType.GuildVoice) {
+        await (ch as any)
+          .send(
+            `🛑 **Force left** voice transcription session in \`${session.channelName}\` (no ingest).`,
+          )
+          .catch(() => {});
+      }
+    } catch {}
+  }
+
+  console.log(`[VOICE] Force left session for guild ${guild.id}`);
+}
+
+/**
+ * Transcribe an audio file using OpenAI Whisper (or return placeholder).
+ * Prepares for easy swap to self-hosted whisper-live-server WS streaming.
+ */
+async function transcribeAudio(
+  filePath: string,
+  speaker: string,
+  sessionForTracking?: any,
+): Promise<string> {
+  const fileBuffer = await fs.promises.readFile(filePath);
+  const filename = path.basename(filePath) || 'speech.wav';
+
+  const sanitize = (raw: any): string => {
+    let s = '';
+    if (typeof raw === 'string') s = raw.trim();
+    else if (raw && typeof raw === 'object' && 'text' in raw)
+      s = String((raw as any).text || '').trim();
+    else s = String(raw || '').trim();
+
+    if (!s) return '[no speech detected]';
+
+    // Hard guard: never let the raw Whisper JSON response (or its string form) or weird server echoes become live text
+    if (
+      s.startsWith('{') &&
+      (s.includes('"text"') || s.includes('"segments"') || s.includes('language'))
+    ) {
+      return '[no speech detected]';
+    }
+    if (s.includes('"text":') && s.includes('"segments"')) {
+      return '[no speech detected]';
+    }
+    // Drop obvious non-transcript server responses
+    if (/^\s*\{.*"language".*\}\s*$/.test(s)) return '[no speech detected]';
+
+    // Drop non-latin short results ONLY if they look like pure server filler (very short, no latin)
+    if (s.length > 1 && s.length < 20 && !/[a-zA-Z]/.test(s)) {
+      return '[no speech detected]';
+    }
+
+    return s; // let short phrases through; the isLowValue in handler will decide live posting
+  };
+
+  // Support local self-hosted Whisper using undici for reliable multipart
+  if (process.env.WHISPER_SERVER_URL) {
+    const localUrl = process.env.WHISPER_SERVER_URL;
+    console.log(`[VOICE] Using local Whisper at ${localUrl} for ${speaker}`);
+    const attemptLocal = async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 300000); // 5 minutes - Whisper can be slow
+      try {
+        const base = localUrl.replace(/\/$/, '');
+        // Better params for quality on conversational/noisy audio
+        const url = `${base}/asr?output=json&task=transcribe&language=en&vad_filter=true&temperature=0&initial_prompt=This is a casual, informal English voice chat in a Discord call between colleagues. People are discussing work, products, tech, and random things. Use natural language.`;
+        const form = new FormData();
+        form.append('audio_file', new Blob([fileBuffer]), filename);
+
+        // Use undici request with explicit signal for timeout control
+        const { body, statusCode } = await request(url, {
+          method: 'POST',
+          body: form as any,
+          signal: controller.signal,
+        });
+
+        if (statusCode < 200 || statusCode >= 300) {
+          let err = '';
+          try {
+            err = await body.text();
+          } catch (readErr: any) {
+            err = readErr.message || 'Could not read error body';
+          }
+          console.error('Local whisper /asr error:', err);
+          return null;
+        } else {
+          let data: any;
+          try {
+            data = await body.json();
+          } catch (readErr: any) {
+            const txt = await body.text().catch(() => '');
+            console.warn('[VOICE] local asr non-json body, raw:', txt.substring(0, 200));
+            data = { text: txt };
+          }
+
+          // Prefer good segments if available (the server returns them)
+          let t = '';
+          if (data.segments && Array.isArray(data.segments)) {
+            const good = data.segments.filter(
+              (seg: any) => (seg.avg_logprob || -2) > -1.0 && (seg.no_speech_prob || 1) < 0.6,
+            );
+            if (good.length > 0) {
+              t = good
+                .map((seg: any) => seg.text || '')
+                .join(' ')
+                .trim();
+            }
+          }
+          if (!t) t = (data.text || '').trim();
+
+          const cleanedT = sanitize(t);
+          if (cleanedT && !cleanedT.includes('no speech')) {
+            if (sessionForTracking) {
+              sessionForTracking.localTranscriptions =
+                (sessionForTracking.localTranscriptions || 0) + 1;
+            }
+            return cleanedT;
+          }
+          return '[no speech detected]';
+        }
+      } catch (e: any) {
+        if (
+          e.name === 'AbortError' ||
+          e.code === 'UND_ERR_HEADERS_TIMEOUT' ||
+          e.code === 'ERR_ASSERTION'
+        ) {
+          console.error(
+            'local transcribe error (timeout or body read error after 5min):',
+            e.message || e,
+          );
+        } else {
+          console.error('local transcribe error', e);
+        }
+        return null;
+      } finally {
+        clearTimeout(timeout);
+      }
+    };
+
+    // Try local, retry once on timeout to handle slow server
+    let result = await attemptLocal();
+    if (result === null) {
+      console.log('[VOICE] Local timed out, retrying once...');
+      await new Promise((r) => setTimeout(r, 2000)); // brief pause
+      result = await attemptLocal();
+    }
+    if (result !== null) {
+      return result;
+    }
+    // fall through to OpenAI only if local completely failed twice
+  }
+
+  // Fallback to OpenAI (cloud) - use verbose_json for segment quality info
+  if (!process.env.OPENAI_API_KEY) {
+    return `[transcription failed for ${speaker}]`;
+  }
+  console.log(`[VOICE] Using OpenAI Whisper for ${speaker}`);
+  try {
+    const form = new FormData();
+    form.append('file', new Blob([fileBuffer]), filename);
+    form.append('model', 'whisper-1');
+    form.append('response_format', 'verbose_json');
+    form.append('language', 'en');
+    const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` },
+      body: form as any,
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      console.error('OpenAI transcribe error:', err);
+      if (err.includes('insufficient_quota')) {
+        console.error(
+          '!!! OPENAI QUOTA EXHAUSTED - add billing credits or disable OpenAI fallback to avoid costs. Relying on local Whisper only.',
+        );
+      }
+      return `[transcription failed for ${speaker}]`;
+    }
+    const data: any = await res.json();
+    let t = (data.text || '').trim();
+    if (data.segments && Array.isArray(data.segments)) {
+      const good = data.segments.filter(
+        (seg: any) => (seg.avg_logprob || -2) > -1.0 && (seg.no_speech_prob || 1) < 0.6,
+      );
+      if (good.length > 0)
+        t = good
+          .map((seg: any) => seg.text || '')
+          .join(' ')
+          .trim();
+    }
+    const cleanedT = sanitize(t);
+    if (cleanedT && !cleanedT.includes('no speech')) {
+      if (sessionForTracking) {
+        sessionForTracking.openaiTranscriptions =
+          (sessionForTracking.openaiTranscriptions || 0) + 1;
+      }
+      return cleanedT;
+    }
+    return '[no speech detected]';
+  } catch (e: any) {
+    console.error('transcribe error', e);
+    return `[transcription error for ${speaker}: ${e.message}]`;
+  }
+}
+
+/**
+ * Ingest helper: tries Supabase (conduit schema source_documents) if env present, else logs.
+ * Matches the conduit.read model used across your stack (chip etc).
+ */
+async function ingestToConduit(doc: {
+  title: string;
+  body: string;
+  source_type: string;
+  metadata: Record<string, any>;
+}) {
+  // Use CONDUIT_ prefixed creds from fyx/.env for the conduit system if available,
+  // falling back to regular SUPABASE for compatibility.
+  const SUPABASE_DB_URL = process.env.CONDUIT_SUPABASE_DB_URL || process.env.SUPABASE_DB_URL;
+  const SUPABASE_URL = process.env.CONDUIT_SUPABASE_URL || process.env.SUPABASE_URL;
+  const SUPABASE_ANON_KEY = process.env.CONDUIT_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+  // Prefer direct pg if available (used by projectsDb and conduit schema)
+  if (SUPABASE_DB_URL) {
+    try {
+      const { Pool } = await import('pg');
+      const pool = new Pool({ connectionString: SUPABASE_DB_URL });
+      // Insert into conduit.source_documents if table exists in this Supabase
+      const sql = `
+        INSERT INTO conduit.source_documents (title, body, source_type, captured_at, metadata)
+        VALUES ($1, $2, $3, NOW(), $4)
+        RETURNING id
+      `;
+      const res = await pool.query(sql, [doc.title, doc.body, doc.source_type, doc.metadata]);
+      await pool.end();
+      console.log('[CONDUIT INGEST] Inserted source_document id=', res.rows[0]?.id);
+      return { ok: true, id: res.rows[0]?.id };
+    } catch (e: any) {
+      console.warn(
+        '[CONDUIT INGEST] pg insert failed (table may not exist or perms), falling back:',
+        e.message,
+      );
+    }
+  }
+
+  // Fallback: use supabase-js if anon keys present (may be RLS limited for writes)
+  if (SUPABASE_URL && SUPABASE_ANON_KEY) {
+    try {
+      const { createClient } = await import('@supabase/supabase-js');
+      const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+      const { data, error } = await supabase
+        .schema('conduit')
+        .from('source_documents')
+        .insert({
+          title: doc.title,
+          body: doc.body,
+          source_type: doc.source_type,
+          captured_at: new Date().toISOString(),
+          metadata: doc.metadata,
+        })
+        .select('id')
+        .single();
+      if (error) throw error;
+      console.log('[CONDUIT INGEST] supabase insert id=', data?.id);
+      return { ok: true, id: data?.id };
+    } catch (e: any) {
+      console.warn('[CONDUIT INGEST] supabase fallback failed:', e.message);
+    }
+  }
+
+  console.log('[CONDUIT INGEST] (stub) would insert:', JSON.stringify(doc, null, 2).slice(0, 500));
+  return { ok: false };
+}
+
+async function executeRun(interaction: CommandInteraction) {
+  const actionOpt = interaction.options.get(COMMAND_VOICE.OPTION_ACTION);
+  // For Channel-type options, .get() returns { value: snowflake (the channel ID) }
+  // This is the pattern used elsewhere in the bot (e.g. Events command).
+  const channelOptRaw = interaction.options.get(COMMAND_VOICE.OPTION_CHANNEL);
+  const action = (actionOpt?.value as string) || '';
+  const channelOpt = channelOptRaw ? String(channelOptRaw.value) : null;
+
+  if (action === COMMAND_VOICE.ACTION_JOIN) {
+    await joinAndListen(interaction.client, interaction, channelOpt);
+  } else if (action === COMMAND_VOICE.ACTION_STOP) {
+    await stopAndIngest(interaction);
+  } else if (action === COMMAND_VOICE.ACTION_STATUS) {
+    await showStatus(interaction);
+  } else if (action === COMMAND_VOICE.ACTION_LEAVE) {
+    await forceLeave(interaction);
+  } else {
+    await interaction.followUp({ content: 'Unknown action. Use join, stop, status, or leave.' });
+  }
+}
+
+const Voice: SlashCommand = {
+  name: COMMAND_VOICE.COMMAND_NAME,
+  description: COMMAND_VOICE.COMMAND_DESCRIPTION,
+  options: [
+    {
+      name: COMMAND_VOICE.OPTION_ACTION,
+      description: COMMAND_VOICE.OPTION_ACTION_DESCRIPTION,
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      choices: [
+        { name: 'join', value: COMMAND_VOICE.ACTION_JOIN },
+        { name: 'stop', value: COMMAND_VOICE.ACTION_STOP },
+        { name: 'status', value: COMMAND_VOICE.ACTION_STATUS },
+        { name: 'leave', value: COMMAND_VOICE.ACTION_LEAVE },
+      ],
+    },
+    {
+      name: COMMAND_VOICE.OPTION_CHANNEL,
+      description: COMMAND_VOICE.OPTION_CHANNEL_DESCRIPTION,
+      type: ApplicationCommandOptionType.Channel,
+      channel_types: [ChannelType.GuildVoice],
+      required: false,
+    },
+  ],
+  run: async (_client: Client, interaction: CommandInteraction) => {
+    try {
+      await executeRun(interaction);
+    } catch (error: any) {
+      console.error('[VOICE CMD ERROR]', error);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.followUp({ content: 'Voice command error. Check logs.' }).catch(() => {});
+      }
+    }
+  },
+};
+
+export default Voice;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -78,6 +78,22 @@ export const GFC_CRON_CONFIG = {
   },
 };
 
+// Voice transcription (Otter.ai style) - bot joins VC, transcribes live-ish, records, ingests to conduit
+export const COMMAND_VOICE = {
+  COMMAND_NAME: 'voice',
+  COMMAND_DESCRIPTION:
+    'Join a voice channel, transcribe conversation (like Otter), stop and ingest to Conduit.',
+  OPTION_ACTION: 'action',
+  OPTION_ACTION_DESCRIPTION: 'join, stop, status, or leave',
+  ACTION_JOIN: 'join',
+  ACTION_STOP: 'stop',
+  ACTION_STATUS: 'status',
+  ACTION_LEAVE: 'leave',
+  OPTION_CHANNEL: 'channel',
+  OPTION_CHANNEL_DESCRIPTION:
+    'Voice channel to join (optional, defaults to CHECKINS or VIRTUAL_OFFICE)',
+};
+
 // The gfc-projects forum channel in the GitFitCode server; each post/thread is a
 // community project. Used by the weekly Project Pulse cron job.
 export const GFC_PROJECTS_FORUM_ID = '1032761290919260262';


### PR DESCRIPTION
## Summary
- New `/voice` command (join/stop/leave): bot joins a voice channel, records per-utterance audio, transcribes via local whisper-live-server (Docker, port 9000) with OpenAI Whisper fallback, and ingests transcript + session context into `conduit.source_documents` via Supabase.
- Registers the command, adds voice constants, and documents it in `docs/COMMANDS.md`.
- Adds pm2 `ecosystem.config.js` and `run-with-node22.sh` deploy helpers (this is how the bot currently runs on the home rig).
- Gitignores `audio/` and `exports/` (large local session artifacts — several GB of WAVs live there locally).

## Status / known gaps
- Real-time STT is partially stubbed; speaking events are captured, full live audio→text depends on whisper-live-server or OpenAI per utterance.
- This code has been running in production on the rig (pm2 `gitfitbot`) — the PR brings the repo in line with the deployed build.

## Test plan
- [ ] `pnpm build` succeeds
- [ ] `/voice` join + stop in a test VC produces a transcript stub in `exports/voice/` and a Conduit ingest log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ETwSRSz1ythJJbMPMH4fk