### PR TITLE
feat: continuous per-user recording with batch transcription at stop

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -126,7 +126,7 @@
 **Actions** (required):
 
 - `join` [channel] : Bot joins (defaults to CHECKINS or VIRTUAL_OFFICE env), starts listening for speakers. **Restricted** — see the consent & recording policy below.
-- `stop` : Leaves VC, produces transcript stub + metadata, saves locally to exports/voice/, ingests to conduit.source_documents (via Supabase if configured).
+- `stop` : Leaves VC, batch-transcribes the full session recording, produces the final transcript + metadata, saves locally to exports/voice/, ingests to conduit.source_documents (via Supabase if configured).
 - `status` : Shows the active session (channel, duration, segment/file counts) for the guild.
 - `leave` : Force-disconnects the bot and clears the session without ingesting.
 - `optout` : Opt yourself out of voice capture and transcription (persisted across sessions and restarts). Replies ephemerally.
@@ -138,4 +138,8 @@
 - **Notification**: When a session starts, the bot posts the usual announcement in the transcript channel **and** sends a notice to everyone currently in the voice channel ("this call is being transcribed by GitFitBot; run `/voice optout` to be excluded"). The notice goes to the voice channel's built-in text chat when possible, with a DM fallback per member. Users who join mid-session receive the same notice once (via the `voiceStateUpdate` listener).
 - **Opt-out**: `/voice optout` is per-user and persisted (local PouchDB). The bot **never subscribes to an opted-out user's audio stream** — no audio file is created and nothing of theirs is transcribed. They still appear in the final transcript's participants list as `username (not transcribed)`. `/voice optin` reverses it. Both take effect immediately, including during an active session.
 
-**Status**: Initial implementation (speaking events captured; full live audio->STT via whisper-live-server or OpenAI pending for real text). Context (channel, participants, times) captured for conduit ingestion.
+**Recording & transcription pipeline**:
+
+- While a session is active, each (non-opted-out) user's audio is recorded **continuously** to rotating 5-minute WAV chunks under `audio/<guildId>-<sessionStartTs>/<userId>/`, with a `manifest.json` in the session dir — a crash loses at most the current chunk.
+- Live captions in the thread stay per-utterance (short clips with quality guards), but they are only captions.
+- The **final transcript** now comes from a full-quality **batch transcription pass over the chunk recordings at `/voice stop`**: the bot posts a "processing full recording…" message, transcribes each chunk (local Whisper first, OpenAI fallback), merges results across users by chunk start time into `[HH:MM:SS] username: text` lines, and uses that for the export + Conduit ingest. Live captions are kept in the export under "Live captions (raw)" for comparison, and are used as a fallback if the batch pass produces nothing. The batch pass is capped at 15 minutes; on timeout, unprocessed chunk file paths are noted.

--- a/src/commands/Voice.ts
+++ b/src/commands/Voice.ts
@@ -5,13 +5,11 @@
  */
 
 import {
-  EndBehaviorType,
   entersState,
   joinVoiceChannel,
   VoiceConnection,
   VoiceConnectionStatus,
 } from '@discordjs/voice';
-import { spawn } from 'child_process';
 import {
   ApplicationCommandOptionType,
   ChannelType,
@@ -23,13 +21,11 @@ import {
 } from 'discord.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as prism from 'prism-media';
 import { request } from 'undici';
 import { SlashCommand } from '../Command';
 import { COMMAND_VOICE } from '../utils/constants';
 import { addVoiceOptOut, fetchAllVoiceOptOuts, removeVoiceOptOut } from '../utils/localdb';
-
-const ffmpegPath: string = require('ffmpeg-static');
+import { ChunkMeta, SessionRecorder } from '../utils/voiceRecorder';
 
 interface VoiceSession {
   connection: VoiceConnection;
@@ -56,6 +52,7 @@ interface VoiceSession {
   pendingTranscriptions: Set<Promise<void>>; // in-flight transcription work, drained on /voice stop
   optOutSet: Set<string>; // user IDs opted out of capture/transcription (cached at start, refreshed on /voice optout|optin)
   notifiedUserIds: Set<string>; // users already sent the recording notice this session
+  recorder: SessionRecorder; // continuous per-user chunk recording + utterance segmentation (#79)
 }
 
 const activeSessions: Map<string, VoiceSession> = new Map();
@@ -120,6 +117,17 @@ export async function notifyMidSessionJoiner(guildId: string, member: GuildMembe
   const session = activeSessions.get(guildId);
   if (!session) return;
   await sendRecordingNotice(session, [member]);
+}
+
+/**
+ * Called from the voiceStateUpdate listener when a user leaves the voice
+ * channel of an active session: closes their continuous recording chunk so
+ * the audio written so far is finalized on disk.
+ */
+export function handleVoiceChannelLeave(guildId: string, userId: string): void {
+  const session = activeSessions.get(guildId);
+  if (!session) return;
+  session.recorder.closeUser(userId, 'left the voice channel');
 }
 
 async function getVoiceChannel(
@@ -235,13 +243,37 @@ async function joinAndListen(
   // refreshes this cache live for all active sessions.
   const optOutSet = new Set(await fetchAllVoiceOptOuts());
 
+  const startedAt = new Date();
+
+  // Continuous per-user recording (#79): one Manual subscription per user,
+  // teed into rotating 5-min chunk WAVs (batch-transcribed at /voice stop)
+  // and a silence segmenter that emits per-utterance WAVs for live captions.
+  // The utterance callback runs the same live-caption pipeline (size skip,
+  // quality guards, thread post) the old AfterSilence path used.
+  const recorder = new SessionRecorder(
+    guildId,
+    startedAt.getTime(),
+    (uid) => session.optOutSet.has(uid),
+    (wavPath, _uid, username) => {
+      // Track the async caption transcription so /voice stop can drain
+      // in-flight work before finalizing (same contract as before, #82).
+      const work = handleUtteranceFile(session, wavPath, username).catch((err) => {
+        console.error(`[VOICE] Live-caption pipeline error for ${username}:`, err);
+      });
+      session.pendingTranscriptions.add(work);
+      void work.finally(() => {
+        session.pendingTranscriptions.delete(work);
+      });
+    },
+  );
+
   const session: VoiceSession = {
     connection,
     client,
     guildId,
     channelId: voiceChannel.id,
     channelName: voiceChannel.name,
-    startedAt: new Date(),
+    startedAt,
     speakingEvents: [],
     transcripts: [],
     audioPaths: [],
@@ -251,6 +283,7 @@ async function joinAndListen(
     pendingTranscriptions: new Set(),
     optOutSet,
     notifiedUserIds: new Set(),
+    recorder,
   };
   activeSessions.set(guildId, session);
 
@@ -369,204 +402,14 @@ async function joinAndListen(
       started: new Date(),
     });
 
-    const audioStream = receiver.subscribe(userId, {
-      end: {
-        behavior: EndBehaviorType.AfterSilence,
-        duration: 3500, // longer to capture more complete phrases in natural conversation
-      },
-    });
-    (audioStream as any).setMaxListeners?.(100);
-
-    const audioDir = path.join(process.cwd(), 'audio');
-    fs.mkdirSync(audioDir, { recursive: true });
-    const filePath = path.join(audioDir, `${userId}-${Date.now()}.wav`);
-    session.audioPaths.push(filePath);
-
-    // Decode opus -> pcm using prism-media, then ffmpeg to wav file
-    let decoder;
-    try {
-      decoder = new prism.opus.Decoder({
-        rate: 48000,
-        channels: 2,
-        frameSize: 960,
-      });
-      (decoder as any).setMaxListeners?.(100);
-    } catch (err) {
-      console.error(`[VOICE] Failed to create opus decoder for ${username}:`, err);
-      // Still track the speaking event for metadata, but skip audio processing/transcription this time.
-      // This prevents the whole process from crashing on native module issues.
-      return;
-    }
-    const pcmStream = audioStream.pipe(decoder);
-
-    const ffmpeg = spawn(ffmpegPath, [
-      '-f',
-      's16le',
-      '-ar',
-      '48000',
-      '-ac',
-      '2',
-      '-i',
-      'pipe:0',
-      '-f',
-      'wav',
-      filePath,
-    ]);
-
-    pcmStream.pipe(ffmpeg.stdin);
-
-    ffmpeg.stderr.on('data', (d) => {
-      // uncomment for debug: console.log('ffmpeg:', d.toString());
-    });
-
-    let closeHandled = false;
-    const handleFfmpegClose = async (code: number | null) => {
-      if (closeHandled) return;
-      closeHandled = true;
-      const stats = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
-      const sizeKb = stats ? Math.round(stats.size / 1024) : 0;
-
-      console.log(
-        `[VOICE] ffmpeg closed for ${username} (code=${code}, size=${sizeKb}KB) at ${filePath}`,
-      );
-
-      // Use the stats from the close event to decide. Some closes have the file "disappear" momentarily or race with existsSync.
-      // Transcribe any file that had content at close time.
-      if (stats && sizeKb >= 15) {
-        console.log(`[VOICE] Starting transcription for ${username}...`);
-        const text = await transcribeAudio(filePath, username, session);
-        const cleaned = (text || '').trim();
-        const ts = new Date().toISOString().slice(11, 19);
-
-        // Track audio usage for cost awareness
-        const stats = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
-        if (stats && session) {
-          const audioSeconds = Math.round(stats.size / 192000); // approx for 48kHz stereo 16-bit
-          session.estimatedAudioSeconds = (session.estimatedAudioSeconds || 0) + audioSeconds;
-        }
-
-        const looksLikeWhisperJson =
-          cleaned.startsWith('{') ||
-          cleaned.includes('"text"') ||
-          cleaned.includes('"segments"') ||
-          /"language"\s*:\s*"/.test(cleaned);
-
-        // Only drop obvious non-speech / json junk from server. Be permissive so real (even short) speech shows as live segments.
-        const isGibberish = cleaned.length > 1 && cleaned.length < 30 && !/[a-zA-Z]/.test(cleaned);
-
-        const wordCount = cleaned.split(/\s+/).filter(Boolean).length;
-
-        // Detect extreme repetition only
-        const lower = cleaned.toLowerCase();
-        const hasRepetition = /\b(\w{3,})\b.*\b\1\b.*\b\1\b/.test(lower); // at least triple repeat
-
-        const isLowValue =
-          !cleaned ||
-          looksLikeWhisperJson ||
-          cleaned.includes('transcription failed') ||
-          cleaned.includes('no speech') ||
-          cleaned.includes('no usable') ||
-          cleaned.trim().length < 1;
-
-        if (!isLowValue) {
-          // Anti-repetition: skip near-duplicates of recent lines (common with Whisper on short/noisy clips)
-          const recentTexts = session.transcripts
-            .slice(-3)
-            .map((line) => line.split(': ').slice(1).join(': ').toLowerCase());
-          const norm = cleaned.toLowerCase().trim();
-          const isRepeat = recentTexts.some(
-            (prev) =>
-              prev &&
-              (norm.includes(prev) || prev.includes(norm)) &&
-              Math.abs(norm.length - prev.length) < 30,
-          );
-          if (isRepeat) {
-            console.log(
-              `[VOICE] ⚠️ Dropped near-duplicate transcription for ${username}: ${cleaned.substring(0, 60)}`,
-            );
-          } else {
-            session.transcripts.push(`[${ts}] ${username}: ${cleaned}`);
-            console.log(
-              `[VOICE] ✅ Transcribed ${username}: ${cleaned.substring(0, 80)}${cleaned.length > 80 ? '...' : ''}`,
-            );
-
-            // Live caption ONLY for useful text -> the target (thread preferred)
-            // This is the key to "live transcript in the thread"
-            if (session.client) {
-              let target: any = session.transcriptThread;
-              if (!target) {
-                const chId =
-                  process.env.VOICE_TRANSCRIPT_CHANNEL_ID ||
-                  process.env.GENERAL_CHAT_CHANNEL_ID ||
-                  '';
-                if (chId) {
-                  target = await session.client.channels.fetch(chId).catch(() => null);
-                }
-              }
-              if (target && 'send' in target) {
-                // Final safety: never post raw JSON responses or empty garbage to the thread
-                const looksLikeRaw =
-                  cleaned.startsWith('{') ||
-                  cleaned.includes('"text"') ||
-                  cleaned.includes('"segments"') ||
-                  /"language"\s*:\s*"/.test(cleaned);
-                if (looksLikeRaw || cleaned.trim().length < 1) {
-                  console.log(
-                    `[VOICE] ⚠️ Final guard blocked bad text for ${username}: ${cleaned.substring(0, 60)}`,
-                  );
-                } else {
-                  const tgtId =
-                    (session.transcriptThread && session.transcriptThread.id) ||
-                    process.env.VOICE_TRANSCRIPT_CHANNEL_ID ||
-                    process.env.GENERAL_CHAT_CHANNEL_ID;
-                  console.log(`[VOICE] Sending live caption for ${username} to ${tgtId}`);
-
-                  // Send as a normal message in the transcript thread.
-                  // Since Discord threads don't support sub-threads like Slack, this is the natural way:
-                  // all content lives linearly in the thread after the "All live segments" header.
-                  // (We previously tried replies for nesting, but given Discord's model, plain messages in the thread are cleaner and more reliable.)
-                  await target.send(`🎙️ **${username}**: ${cleaned}`).catch((e: any) => {
-                    console.warn('[VOICE] live send failed:', e?.message || e);
-                  });
-                }
-              }
-            }
-          }
-        } else {
-          console.log(
-            `[VOICE] ⚠️ Dropped low-value segment for ${username}: ${cleaned.substring(0, 60)}`,
-          );
-        }
-      } else if (sizeKb < 15) {
-        console.log(
-          `[VOICE] ⚠️ Skipping tiny clip (${sizeKb}KB < 15KB) for ${username} (too short for reliable STT)`,
-        );
-      } else {
-        console.log(
-          `[VOICE] ⚠️ Audio file for ${username} ready at ${filePath} (ffmpeg code=${code})`,
-        );
-      }
-
-      // Cleanup streams to prevent listener leaks
-      try {
-        audioStream.destroy();
-      } catch {}
-      try {
-        if (decoder && !decoder.destroyed) decoder.destroy();
-      } catch {}
-    };
-
-    ffmpeg.on('close', (code) => {
-      // Track the async transcription work so /voice stop can drain in-flight
-      // transcriptions before building/exporting/ingesting the final transcript.
-      const work = handleFfmpegClose(code).catch((err) => {
-        console.error(`[VOICE] Transcription pipeline error for ${username}:`, err);
-      });
-      session.pendingTranscriptions.add(work);
-      void work.finally(() => {
-        session.pendingTranscriptions.delete(work);
-      });
-    });
+    // Continuous capture (#79): first speaking event subscribes the user with
+    // EndBehaviorType.Manual and tees decoded PCM into rotating chunk WAVs +
+    // the utterance segmenter (live captions). Subsequent events are no-ops.
+    // (Two parallel receiver subscriptions per user are NOT possible:
+    // VoiceReceiver.subscribe() returns the existing stream for a user, so the
+    // old AfterSilence path could not coexist with the continuous one — see
+    // the architecture note in src/utils/voiceRecorder.ts.)
+    session.recorder.ensureUser(receiver, userId, username);
   });
 
   receiver.speaking.on('end', (userId: string) => {
@@ -580,6 +423,114 @@ async function joinAndListen(
   // For now console + followUp already done. In prod post to GENERAL or dedicated transcript channel.
 
   console.log(`[VOICE] Session started in guild ${guildId} channel ${voiceChannel.id}`);
+}
+
+/**
+ * Live-caption pipeline for one utterance WAV (emitted by the recorder's
+ * silence segmenter). This is the old per-utterance AfterSilence path,
+ * unchanged in behavior: <15KB skip, transcription, JSON/gibberish/low-value
+ * guards, near-duplicate suppression, and the thread caption post. These
+ * guards stay HERE only — the final transcript comes from the clean batch
+ * pass over the continuous chunks at /voice stop (#79).
+ */
+async function handleUtteranceFile(
+  session: VoiceSession,
+  filePath: string,
+  username: string,
+): Promise<void> {
+  session.audioPaths.push(filePath);
+
+  const stats = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
+  const sizeKb = stats ? Math.round(stats.size / 1024) : 0;
+
+  console.log(`[VOICE] Utterance WAV ready for ${username} (size=${sizeKb}KB) at ${filePath}`);
+
+  if (!stats || sizeKb < 15) {
+    console.log(
+      `[VOICE] ⚠️ Skipping tiny clip (${sizeKb}KB < 15KB) for ${username} (too short for reliable STT)`,
+    );
+    return;
+  }
+
+  console.log(`[VOICE] Starting transcription for ${username}...`);
+  const text = await transcribeAudio(filePath, username, session);
+  const cleaned = (text || '').trim();
+  const ts = new Date().toISOString().slice(11, 19);
+
+  // Track audio usage for cost awareness
+  const audioSeconds = Math.round(stats.size / 192000); // approx for 48kHz stereo 16-bit
+  session.estimatedAudioSeconds = (session.estimatedAudioSeconds || 0) + audioSeconds;
+
+  const looksLikeWhisperJson =
+    cleaned.startsWith('{') ||
+    cleaned.includes('"text"') ||
+    cleaned.includes('"segments"') ||
+    /"language"\s*:\s*"/.test(cleaned);
+
+  const isLowValue =
+    !cleaned ||
+    looksLikeWhisperJson ||
+    cleaned.includes('transcription failed') ||
+    cleaned.includes('no speech') ||
+    cleaned.includes('no usable') ||
+    cleaned.trim().length < 1;
+
+  if (isLowValue) {
+    console.log(
+      `[VOICE] ⚠️ Dropped low-value segment for ${username}: ${cleaned.substring(0, 60)}`,
+    );
+    return;
+  }
+
+  // Anti-repetition: skip near-duplicates of recent lines (common with Whisper on short/noisy clips)
+  const recentTexts = session.transcripts
+    .slice(-3)
+    .map((line) => line.split(': ').slice(1).join(': ').toLowerCase());
+  const norm = cleaned.toLowerCase().trim();
+  const isRepeat = recentTexts.some(
+    (prev) =>
+      prev &&
+      (norm.includes(prev) || prev.includes(norm)) &&
+      Math.abs(norm.length - prev.length) < 30,
+  );
+  if (isRepeat) {
+    console.log(
+      `[VOICE] ⚠️ Dropped near-duplicate transcription for ${username}: ${cleaned.substring(0, 60)}`,
+    );
+    return;
+  }
+
+  session.transcripts.push(`[${ts}] ${username}: ${cleaned}`);
+  console.log(
+    `[VOICE] ✅ Transcribed ${username}: ${cleaned.substring(0, 80)}${cleaned.length > 80 ? '...' : ''}`,
+  );
+
+  // Live caption ONLY for useful text -> the target (thread preferred)
+  // This is the key to "live transcript in the thread"
+  if (session.client) {
+    let target: any = session.transcriptThread;
+    if (!target) {
+      const chId =
+        process.env.VOICE_TRANSCRIPT_CHANNEL_ID || process.env.GENERAL_CHAT_CHANNEL_ID || '';
+      if (chId) {
+        target = await session.client.channels.fetch(chId).catch(() => null);
+      }
+    }
+    if (target && 'send' in target) {
+      const tgtId =
+        (session.transcriptThread && session.transcriptThread.id) ||
+        process.env.VOICE_TRANSCRIPT_CHANNEL_ID ||
+        process.env.GENERAL_CHAT_CHANNEL_ID;
+      console.log(`[VOICE] Sending live caption for ${username} to ${tgtId}`);
+
+      // Send as a normal message in the transcript thread.
+      // Since Discord threads don't support sub-threads like Slack, this is the natural way:
+      // all content lives linearly in the thread after the "All live segments" header.
+      await target.send(`🎙️ **${username}**: ${cleaned}`).catch((e: any) => {
+        console.warn('[VOICE] live send failed:', e?.message || e);
+      });
+    }
+  }
 }
 
 async function stopAndIngest(interaction: CommandInteraction) {
@@ -604,6 +555,15 @@ async function stopAndIngest(interaction: CommandInteraction) {
 
   await interaction.followUp({
     content: 'Session ended — finalizing transcript (waiting for in-flight transcriptions)…',
+  });
+
+  // Close all continuous recordings first: this finalizes every chunk WAV on
+  // disk and flushes any in-progress utterance (whose caption transcription
+  // gets registered in pendingTranscriptions before stopAll resolves), so the
+  // drain below covers it.
+  const recordedChunks = await session.recorder.stopAll().catch((e: any) => {
+    console.warn('[VOICE] Recorder stop failed:', e?.message || e);
+    return [] as ChunkMeta[];
   });
 
   // Drain in-flight transcriptions (ffmpeg close handlers + queued Whisper calls)
@@ -653,8 +613,10 @@ async function stopAndIngest(interaction: CommandInteraction) {
     })
     .join('\n');
 
-  // Improved formatting + basic categorization: group consecutive lines from same speaker
-  let realTranscripts = 'No transcribed segments (check OPENAI_API_KEY or audio files in ./audio)';
+  // Live-caption transcript (grouped by speaker) — kept as the raw record and
+  // as the fallback if the batch pass over the full recording produces nothing.
+  let liveCaptionTranscript =
+    'No transcribed segments (check OPENAI_API_KEY or audio files in ./audio)';
   if (session.transcripts && session.transcripts.length > 0) {
     const grouped: Array<{ speaker: string; lines: string[] }> = [];
     let currSpeaker = '';
@@ -672,11 +634,21 @@ async function stopAndIngest(interaction: CommandInteraction) {
       currLines.push(content);
     }
     if (currSpeaker) grouped.push({ speaker: currSpeaker, lines: currLines });
-    realTranscripts = grouped.map((g) => `**${g.speaker}:**\n${g.lines.join('\n')}`).join('\n\n');
+    liveCaptionTranscript = grouped
+      .map((g) => `**${g.speaker}:**\n${g.lines.join('\n')}`)
+      .join('\n\n');
   }
   if (droppedSegments > 0) {
-    realTranscripts += `\n\n⚠️ ${droppedSegments} segment(s) were still transcribing at stop and were dropped (drain timed out after ${DRAIN_TIMEOUT_MS / 1000}s).`;
+    liveCaptionTranscript += `\n\n⚠️ ${droppedSegments} caption segment(s) were still transcribing at stop and were dropped (drain timed out after ${DRAIN_TIMEOUT_MS / 1000}s).`;
   }
+
+  // Batch pass over the continuous chunk recordings (#79): full-quality
+  // transcription of everything captured, merged across users by chunk start
+  // time. This becomes the final transcript; live captions are kept for
+  // comparison. Falls back to live captions when no chunks transcribed.
+  const batch = await transcribeSessionRecordings(session, recordedChunks);
+  const usedBatchTranscript = batch.merged !== null;
+  const realTranscripts = batch.merged ?? liveCaptionTranscript;
 
   const localCount = session.localTranscriptions || 0;
   const openaiCount = session.openaiTranscriptions || 0;
@@ -694,13 +666,14 @@ async function stopAndIngest(interaction: CommandInteraction) {
     `- Local transcriptions: ${localCount}\n` +
     `- OpenAI Whisper calls: ${openaiCount}\n` +
     `- Estimated audio processed: ~${Math.round(totalSeconds)}s\n` +
-    `- Rough OpenAI cost (if any): $${roughCost} (only counts OpenAI path)\n\n` +
+    `- Rough OpenAI cost (if any): $${roughCost} (only counts OpenAI path)\n` +
+    `- Batch pass: ${batch.note}\n\n` +
     `## Transcribed conversation\n${realTranscripts}\n\n` +
+    `## Live captions (raw)\n${liveCaptionTranscript}\n\n` +
     `## Raw speaking events\n${eventsSummary || 'No events'}\n\n` +
-    `**Audio files**: ${session.audioPaths?.join(', ') || 'none'}\n` +
-    `**Note**: Audio was recorded per utterance. Prefer local Whisper to avoid costs. Local errors fall back to OpenAI.\n`;
-
-  // TODO: full audio recording + STT here. For now, use this stub + metadata.
+    `**Session recording dir**: ${session.recorder.sessionDir}\n` +
+    `**Utterance audio files**: ${session.audioPaths?.join(', ') || 'none'}\n` +
+    `**Note**: Audio is recorded continuously per user in 5-minute chunks; the "Transcribed conversation" above comes from a full-quality batch pass over those chunks at stop${usedBatchTranscript ? '' : ' (batch produced nothing — live captions used as fallback)'}. Prefer local Whisper to avoid costs. Local errors fall back to OpenAI.\n`;
 
   // Ingest to conduit (best effort using Supabase if configured, else local export)
   const ingestResult = await ingestToConduit({
@@ -731,9 +704,10 @@ async function stopAndIngest(interaction: CommandInteraction) {
 
   const summary =
     `**Session ended.** Duration ~${durationMin}m. ` +
-    `Transcript stub saved to ${filePath}. Ingest status: ${ingestResult.ok ? 'OK (doc ID: ' + (ingestResult.id ?? 'unknown') + ')' : 'logged (no full conduit yet)'}.\n\n` +
+    `Transcript saved to ${filePath}. Ingest status: ${ingestResult.ok ? 'OK (doc ID: ' + (ingestResult.id ?? 'unknown') + ')' : 'logged (no full conduit yet)'}.\n\n` +
+    `Final transcript: ${usedBatchTranscript ? `batch pass over ${recordedChunks.length} recorded chunk(s)` : 'live captions (batch pass produced nothing)'}.\n` +
     `Usage: ${localCount} local + ${openaiCount} OpenAI transcriptions (~${Math.round(totalSeconds)}s audio). Rough OpenAI cost ~$${roughCost}.\n` +
-    `Audio files: ${session.audioPaths?.join(', ') || 'none'}`;
+    `Recording dir: ${session.recorder.sessionDir}`;
 
   await interaction.followUp({ content: summary });
 
@@ -748,7 +722,7 @@ async function stopAndIngest(interaction: CommandInteraction) {
   if (summaryTarget && 'send' in summaryTarget) {
     const summaryContent =
       `✅ **Transcription session in \`${channelName}\` ended.**\n` +
-      `Duration: ~${durationMin}m | Segments: ${session.transcripts?.length || 0}\n` +
+      `Duration: ~${durationMin}m | Live segments: ${session.transcripts?.length || 0} | Recorded chunks: ${recordedChunks.length}\n` +
       `Usage: ${localCount} local + ${openaiCount} OpenAI (~${Math.round(totalSeconds)}s). Rough OpenAI cost ~$${roughCost}.\n` +
       `${ingestResult.ok ? '✅ Ingested to Conduit (doc ID logged in bot)' : '⚠️ Ingest may have failed — check logs'}\n` +
       `Full transcript saved locally too.`;
@@ -775,8 +749,9 @@ async function showStatus(interaction: CommandInteraction) {
     content =
       `**Active session in ${session.channelName}**\n` +
       `Started: ${session.startedAt.toISOString()} (~${durationMin}m ago)\n` +
-      `Segments transcribed: ${segs}\n` +
-      `Audio files captured: ${files}\n` +
+      `Segments transcribed (live captions): ${segs}\n` +
+      `Utterance audio files: ${files}\n` +
+      `Continuous recording chunks: ${session.recorder.chunks.length} (dir: ${session.recorder.sessionDir})\n` +
       `Local transcriptions: ${session.localTranscriptions || 0} | OpenAI: ${session.openaiTranscriptions || 0}\n` +
       `Est. audio: ~${Math.round(session.estimatedAudioSeconds || 0)}s\n` +
       `Use \`/voice stop\` to end and ingest to Conduit, or \`/voice leave\` to force disconnect.`;
@@ -824,6 +799,118 @@ async function forceLeave(interaction: CommandInteraction) {
   }
 
   console.log(`[VOICE] Force left session for guild ${guild.id}`);
+}
+
+/**
+ * Batch transcription pass over the continuous chunk recordings (#79).
+ *
+ * Runs each recorded chunk (chronological across all users) through
+ * transcribeAudio — which already handles local-Whisper serialization, the
+ * OpenAI fallback, and segment quality filtering — and merges the results by
+ * chunk start time into "[HH:MM:SS] username: text" lines.
+ *
+ * Posts a "processing…" message to the session thread and edits it when done.
+ * Total batch time is capped at 15 minutes; on timeout, whatever completed is
+ * kept and the remaining chunks are reported (with file paths) as unprocessed.
+ *
+ * Returns merged === null when nothing was transcribed (no chunks / all
+ * failed) so the caller can fall back to the live-caption transcript.
+ */
+const BATCH_TRANSCRIBE_TIMEOUT_MS = 15 * 60 * 1000;
+
+async function transcribeSessionRecordings(
+  session: VoiceSession,
+  chunks: ChunkMeta[],
+): Promise<{ merged: string | null; note: string }> {
+  const usable = chunks.filter((c) => {
+    try {
+      return fs.statSync(c.filePath).size > 1024; // skip empty/header-only WAVs
+    } catch {
+      return false;
+    }
+  });
+  if (usable.length === 0) {
+    return { merged: null, note: 'no recorded chunks to batch-transcribe' };
+  }
+
+  // Post the "processing" notice to the session thread (or fallback channel).
+  let target: any = session.transcriptThread;
+  if (!target && session.client) {
+    const chId = process.env.VOICE_TRANSCRIPT_CHANNEL_ID || process.env.GENERAL_CHAT_CHANNEL_ID;
+    if (chId) {
+      target = await session.client.channels.fetch(chId).catch(() => null);
+    }
+  }
+  let processingMsg: any = null;
+  if (target && 'send' in target) {
+    processingMsg = await target
+      .send(
+        `⏳ Processing full session recording (${usable.length} chunk(s))… the final transcript will use this clean batch pass.`,
+      )
+      .catch(() => null);
+  }
+
+  const startedProcessing = Date.now();
+  const deadline = startedProcessing + BATCH_TRANSCRIBE_TIMEOUT_MS;
+  const lines: string[] = [];
+  const unprocessed: string[] = [];
+  let transcribedCount = 0;
+
+  for (const chunk of usable) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      unprocessed.push(chunk.filePath);
+      continue;
+    }
+    let text: string | null = null;
+    let capTimer: NodeJS.Timeout | undefined;
+    try {
+      // Race each chunk against the remaining global budget. We can't cancel
+      // the underlying Whisper call, but we stop waiting for it.
+      text = await Promise.race([
+        transcribeAudio(chunk.filePath, chunk.username, session),
+        new Promise<null>((resolve) => {
+          capTimer = setTimeout(() => resolve(null), remaining);
+        }),
+      ]);
+    } catch (err: any) {
+      console.error(
+        `[VOICE] Batch transcription failed for chunk ${chunk.filePath}:`,
+        err?.message || err,
+      );
+    } finally {
+      if (capTimer) clearTimeout(capTimer);
+    }
+    if (text === null) {
+      unprocessed.push(chunk.filePath);
+      continue;
+    }
+    transcribedCount++;
+    const cleaned = (text || '').trim();
+    const isLowValue =
+      !cleaned ||
+      cleaned.includes('no speech') ||
+      cleaned.includes('transcription failed') ||
+      cleaned.includes('transcription error');
+    if (isLowValue) continue;
+    lines.push(`[${chunk.startedAt.slice(11, 19)}] ${chunk.username}: ${cleaned}`);
+  }
+
+  const elapsedSec = Math.round((Date.now() - startedProcessing) / 1000);
+  let note = `${transcribedCount}/${usable.length} chunk(s) transcribed in ${elapsedSec}s`;
+  if (unprocessed.length > 0) {
+    note += `; ⚠️ batch cap (${BATCH_TRANSCRIBE_TIMEOUT_MS / 60000} min) hit — ${unprocessed.length} chunk(s) left unprocessed: ${unprocessed.join(', ')}`;
+  }
+
+  if (processingMsg && typeof processingMsg.edit === 'function') {
+    const doneContent =
+      lines.length > 0
+        ? `✅ Full recording processed: ${note}.`
+        : `⚠️ Full recording processed but produced no usable text (${note}). Falling back to live captions.`;
+    await processingMsg.edit(doneContent.slice(0, 1900)).catch(() => {});
+  }
+
+  return { merged: lines.length > 0 ? lines.join('\n') : null, note };
 }
 
 /**
@@ -1139,6 +1226,9 @@ async function setVoiceOptOut(interaction: CommandInteraction, optedOut: boolean
   for (const session of activeSessions.values()) {
     if (optedOut) {
       session.optOutSet.add(userId);
+      // Also stop any continuous recording already open for this user —
+      // opting out must halt capture immediately, not just future subscribes.
+      session.recorder.closeUser(userId, 'opted out');
     } else {
       session.optOutSet.delete(userId);
     }

--- a/src/listeners/voiceStateUpdate.ts
+++ b/src/listeners/voiceStateUpdate.ts
@@ -10,24 +10,40 @@
 
 import { Client, VoiceState } from 'discord.js';
 import 'dotenv/config';
-import { getActiveSessionChannel, notifyMidSessionJoiner } from '../commands/Voice';
+import {
+  getActiveSessionChannel,
+  handleVoiceChannelLeave,
+  notifyMidSessionJoiner,
+} from '../commands/Voice';
 
 export default (client: Client): void => {
   client.on('voiceStateUpdate', async (oldState: VoiceState, newState: VoiceState) => {
-    const member = newState.member;
+    const member = newState.member ?? oldState.member;
     if (!member || member.user.bot) return;
 
-    // Only care about actually entering a channel (not mute/deafen/stream
-    // changes within the same channel).
-    if (!newState.channelId || newState.channelId === oldState.channelId) return;
+    // Ignore mute/deafen/stream changes within the same channel.
+    if (newState.channelId === oldState.channelId) return;
 
     const activeChannelId = getActiveSessionChannel(newState.guild.id);
-    if (!activeChannelId || newState.channelId !== activeChannelId) return;
+    if (!activeChannelId) return;
 
-    try {
-      await notifyMidSessionJoiner(newState.guild.id, member);
-    } catch (error) {
-      console.warn('[VOICE] Failed to notify mid-session joiner:', error);
+    // User left the session's voice channel: finalize their continuous
+    // recording chunk so the audio captured so far is intact on disk (#79).
+    if (oldState.channelId === activeChannelId && newState.channelId !== activeChannelId) {
+      try {
+        handleVoiceChannelLeave(newState.guild.id, member.id);
+      } catch (error) {
+        console.warn('[VOICE] Failed to close recording for leaving member:', error);
+      }
+    }
+
+    // User joined the session's voice channel: one-time consent notice.
+    if (newState.channelId === activeChannelId) {
+      try {
+        await notifyMidSessionJoiner(newState.guild.id, member);
+      } catch (error) {
+        console.warn('[VOICE] Failed to notify mid-session joiner:', error);
+      }
     }
   });
 };

--- a/src/utils/voiceRecorder.ts
+++ b/src/utils/voiceRecorder.ts
@@ -1,0 +1,374 @@
+/**
+ * Continuous per-user voice recording for /voice sessions (#79).
+ *
+ * ARCHITECTURE NOTE — one subscription per user (why we tee):
+ * @discordjs/voice's `VoiceReceiver.subscribe()` returns the EXISTING
+ * `AudioReceiveStream` when one is already open for that user (its
+ * implementation is literally `const existing = this.subscriptions.get(userId);
+ * if (existing) return existing;` — the second call's end-behavior options are
+ * silently ignored). So we CANNOT hold a continuous (EndBehaviorType.Manual)
+ * subscription and a per-utterance (AfterSilence) subscription simultaneously.
+ * Instead we hold ONE Manual subscription per user, decode opus → PCM once,
+ * and tee the PCM into:
+ *   1. rotating 5-minute chunk WAVs (the durable full-session recording used
+ *      by the batch transcription pass at /voice stop), and
+ *   2. a per-utterance silence segmenter for live captions: Discord stops
+ *      sending opus packets while a user is silent, so a >3.5s gap in decoded
+ *      PCM arrival marks an utterance boundary — equivalent to the old
+ *      AfterSilence(3500) behavior. Each utterance is written to its own
+ *      small WAV and handed to the caller's `onUtterance` callback (which
+ *      keeps the existing live-caption pipeline: <15KB skip, quality guards,
+ *      thread post).
+ *
+ * Disk layout: audio/<guildId>-<sessionStartTs>/<userId>/chunk-<startEpochMs>.wav
+ * plus a manifest.json in the session dir (rewritten on every chunk open/close)
+ * so a crash mid-session leaves usable, attributable audio on disk.
+ *
+ * NOTE on chunk timing: because Discord sends no packets during silence, a
+ * chunk file contains only speech (silence gaps are collapsed). Chunks are
+ * ordered/attributed by their wall-clock start time, which is what the batch
+ * transcript merge uses.
+ */
+
+import { AudioReceiveStream, EndBehaviorType, VoiceReceiver } from '@discordjs/voice';
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as prism from 'prism-media';
+
+const ffmpegPath: string = require('ffmpeg-static');
+
+export interface ChunkMeta {
+  userId: string;
+  username: string;
+  /** ISO timestamp of (approximately) the first audio written to the chunk. */
+  startedAt: string;
+  filePath: string;
+}
+
+export type UtteranceHandler = (wavPath: string, userId: string, username: string) => void;
+
+const CHUNK_ROTATE_MS = 5 * 60 * 1000; // rotate chunk files every 5 minutes
+const UTTERANCE_SILENCE_MS = 3500; // same boundary the old AfterSilence path used
+const STOP_FLUSH_TIMEOUT_MS = 10_000; // max wait for ffmpeg processes to finish at stop
+
+interface UserRecorderState {
+  userId: string;
+  username: string;
+  opusStream: AudioReceiveStream;
+  decoder: prism.opus.Decoder;
+  onPcm: (buf: Buffer) => void;
+  // Continuous chunk writer
+  chunkFfmpeg: ChildProcessWithoutNullStreams | null;
+  chunkOpenedAt: number; // epoch ms
+  // Per-utterance segmenter (live captions)
+  uttFfmpeg: ChildProcessWithoutNullStreams | null;
+  uttPath: string | null;
+  uttTimer: NodeJS.Timeout | null;
+  closed: boolean;
+}
+
+function spawnWavWriter(filePath: string): ChildProcessWithoutNullStreams {
+  const ffmpeg = spawn(ffmpegPath, [
+    '-f',
+    's16le',
+    '-ar',
+    '48000',
+    '-ac',
+    '2',
+    '-i',
+    'pipe:0',
+    '-f',
+    'wav',
+    '-y',
+    filePath,
+  ]);
+  ffmpeg.stderr.on('data', () => {
+    // uncomment for debug: console.log('ffmpeg:', d.toString());
+  });
+  return ffmpeg;
+}
+
+function safeWrite(proc: ChildProcessWithoutNullStreams | null, buf: Buffer): void {
+  try {
+    if (proc && !proc.killed && proc.stdin.writable) proc.stdin.write(buf);
+  } catch {
+    // stdin may race with process exit; audio loss here is at most one frame
+  }
+}
+
+function safeEndStdin(proc: ChildProcessWithoutNullStreams | null): void {
+  try {
+    if (proc && !proc.killed && proc.stdin.writable) proc.stdin.end();
+  } catch {}
+}
+
+export class SessionRecorder {
+  readonly sessionDir: string;
+
+  /** Per-chunk metadata (also persisted to manifest.json in the session dir). */
+  readonly chunks: ChunkMeta[] = [];
+
+  private readonly users = new Map<string, UserRecorderState>();
+
+  private readonly pendingFfmpegCloses = new Set<Promise<void>>();
+
+  private stopped = false;
+
+  constructor(
+    private readonly guildId: string,
+    private readonly sessionStartTs: number,
+    private readonly isOptedOut: (userId: string) => boolean,
+    private readonly onUtterance: UtteranceHandler,
+    baseAudioDir: string = path.join(process.cwd(), 'audio'),
+  ) {
+    this.sessionDir = path.join(baseAudioDir, `${guildId}-${sessionStartTs}`);
+    fs.mkdirSync(this.sessionDir, { recursive: true });
+    this.persistManifest();
+  }
+
+  /**
+   * Begins (or continues) continuous capture for a user. Called on every
+   * speaking-start event; only the first call per user actually subscribes.
+   * Never records opted-out users.
+   */
+  ensureUser(receiver: VoiceReceiver, userId: string, username: string): void {
+    if (this.stopped || this.isOptedOut(userId) || this.users.has(userId)) return;
+
+    let decoder: prism.opus.Decoder;
+    try {
+      decoder = new prism.opus.Decoder({ rate: 48000, channels: 2, frameSize: 960 });
+      (decoder as any).setMaxListeners?.(100);
+    } catch (err) {
+      console.error(`[VOICE REC] Failed to create opus decoder for ${username}:`, err);
+      return;
+    }
+
+    // Continuous subscription: lives until the user leaves / opts out / stop.
+    const opusStream = receiver.subscribe(userId, {
+      end: { behavior: EndBehaviorType.Manual },
+    });
+    (opusStream as any).setMaxListeners?.(100);
+
+    const state: UserRecorderState = {
+      userId,
+      username,
+      opusStream,
+      decoder,
+      onPcm: () => {},
+      chunkFfmpeg: null,
+      chunkOpenedAt: 0,
+      uttFfmpeg: null,
+      uttPath: null,
+      uttTimer: null,
+      closed: false,
+    };
+    state.onPcm = (buf: Buffer) => this.handlePcm(state, buf);
+
+    opusStream.pipe(decoder);
+    decoder.on('data', state.onPcm);
+    decoder.on('error', (err) => {
+      console.error(`[VOICE REC] Decoder error for ${username}:`, err?.message || err);
+    });
+    opusStream.on('error', (err: any) => {
+      console.error(`[VOICE REC] Receive stream error for ${username}:`, err?.message || err);
+    });
+
+    this.users.set(userId, state);
+    console.log(`[VOICE REC] Continuous recording started for ${username} (${userId})`);
+  }
+
+  /** True if this user currently has a continuous recording open. */
+  isRecording(userId: string): boolean {
+    return this.users.has(userId);
+  }
+
+  /**
+   * Stops capturing a user (left the VC or opted out mid-session): closes
+   * their current chunk and flushes any in-progress utterance so its live
+   * caption still fires.
+   */
+  closeUser(userId: string, reason = 'left'): void {
+    const state = this.users.get(userId);
+    if (!state) return;
+    console.log(`[VOICE REC] Closing recording for ${state.username} (${reason})`);
+    this.teardownUser(state);
+    this.users.delete(userId);
+  }
+
+  /**
+   * Ends the session: closes every user's streams and chunk files, waits for
+   * ffmpeg writers to flush (bounded), persists the final manifest, and
+   * returns chunk metadata in chronological order.
+   */
+  async stopAll(): Promise<ChunkMeta[]> {
+    this.stopped = true;
+    for (const state of this.users.values()) this.teardownUser(state);
+    this.users.clear();
+
+    if (this.pendingFfmpegCloses.size > 0) {
+      let timer: NodeJS.Timeout | undefined;
+      await Promise.race([
+        Promise.allSettled([...this.pendingFfmpegCloses]),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, STOP_FLUSH_TIMEOUT_MS);
+        }),
+      ]);
+      if (timer) clearTimeout(timer);
+    }
+
+    this.persistManifest();
+    return this.sortedChunks();
+  }
+
+  sortedChunks(): ChunkMeta[] {
+    return [...this.chunks].sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+  }
+
+  // ---------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------
+
+  private handlePcm(state: UserRecorderState, buf: Buffer): void {
+    if (state.closed || this.stopped) return;
+    // Opt-out can flip mid-session between speaking events; never write audio
+    // for a user who is now opted out.
+    if (this.isOptedOut(state.userId)) return;
+
+    // 1) Continuous chunk writer (rotate every CHUNK_ROTATE_MS of wall time).
+    const now = Date.now();
+    if (!state.chunkFfmpeg || now - state.chunkOpenedAt >= CHUNK_ROTATE_MS) {
+      this.rotateChunk(state, now);
+    }
+    safeWrite(state.chunkFfmpeg, buf);
+
+    // 2) Utterance segmenter for live captions: a >UTTERANCE_SILENCE_MS gap in
+    //    decoded PCM arrival ends the current utterance (Discord sends no
+    //    packets during silence).
+    if (!state.uttFfmpeg) this.openUtterance(state, now);
+    safeWrite(state.uttFfmpeg, buf);
+    if (state.uttTimer) clearTimeout(state.uttTimer);
+    state.uttTimer = setTimeout(() => this.closeUtterance(state), UTTERANCE_SILENCE_MS);
+  }
+
+  private rotateChunk(state: UserRecorderState, now: number): void {
+    this.closeChunk(state);
+
+    const userDir = path.join(this.sessionDir, state.userId);
+    fs.mkdirSync(userDir, { recursive: true });
+    const filePath = path.join(userDir, `chunk-${now}.wav`);
+
+    const ffmpeg = spawnWavWriter(filePath);
+    this.trackFfmpegClose(ffmpeg, `chunk ${path.basename(filePath)} (${state.username})`);
+
+    state.chunkFfmpeg = ffmpeg;
+    state.chunkOpenedAt = now;
+    this.chunks.push({
+      userId: state.userId,
+      username: state.username,
+      startedAt: new Date(now).toISOString(),
+      filePath,
+    });
+    // Persist on open so a crash mid-chunk still leaves the manifest entry
+    // pointing at the (partially written but decodable) WAV.
+    this.persistManifest();
+    console.log(`[VOICE REC] Opened chunk for ${state.username}: ${filePath}`);
+  }
+
+  private closeChunk(state: UserRecorderState): void {
+    if (!state.chunkFfmpeg) return;
+    safeEndStdin(state.chunkFfmpeg);
+    state.chunkFfmpeg = null;
+  }
+
+  private openUtterance(state: UserRecorderState, now: number): void {
+    // Utterance WAVs are transient caption inputs — keep them in the flat
+    // audio/ dir (same location/naming the old per-utterance path used).
+    const audioDir = path.join(this.sessionDir, '..');
+    fs.mkdirSync(audioDir, { recursive: true });
+    const uttPath = path.join(audioDir, `${state.userId}-${now}.wav`);
+
+    const ffmpeg = spawnWavWriter(uttPath);
+    state.uttFfmpeg = ffmpeg;
+    state.uttPath = uttPath;
+
+    const { userId, username } = state;
+    const closePromise = new Promise<void>((resolve) => {
+      ffmpeg.on('close', () => {
+        try {
+          this.onUtterance(uttPath, userId, username);
+        } catch (err) {
+          console.error(`[VOICE REC] onUtterance handler error for ${username}:`, err);
+        }
+        resolve();
+      });
+      ffmpeg.on('error', (err) => {
+        console.error(`[VOICE REC] Utterance ffmpeg error for ${username}:`, err);
+        resolve();
+      });
+    });
+    this.pendingFfmpegCloses.add(closePromise);
+    void closePromise.finally(() => this.pendingFfmpegCloses.delete(closePromise));
+  }
+
+  private closeUtterance(state: UserRecorderState): void {
+    if (state.uttTimer) {
+      clearTimeout(state.uttTimer);
+      state.uttTimer = null;
+    }
+    if (!state.uttFfmpeg) return;
+    safeEndStdin(state.uttFfmpeg);
+    state.uttFfmpeg = null;
+    state.uttPath = null;
+  }
+
+  private teardownUser(state: UserRecorderState): void {
+    if (state.closed) return;
+    state.closed = true;
+    try {
+      state.decoder.off('data', state.onPcm);
+    } catch {}
+    try {
+      state.opusStream.destroy(); // Manual streams only end when destroyed
+    } catch {}
+    try {
+      if (!state.decoder.destroyed) state.decoder.destroy();
+    } catch {}
+    this.closeUtterance(state);
+    this.closeChunk(state);
+  }
+
+  private trackFfmpegClose(ffmpeg: ChildProcessWithoutNullStreams, label: string): void {
+    const closePromise = new Promise<void>((resolve) => {
+      ffmpeg.on('close', (code) => {
+        console.log(`[VOICE REC] ffmpeg closed for ${label} (code=${code})`);
+        this.persistManifest();
+        resolve();
+      });
+      ffmpeg.on('error', (err) => {
+        console.error(`[VOICE REC] ffmpeg error for ${label}:`, err);
+        resolve();
+      });
+    });
+    this.pendingFfmpegCloses.add(closePromise);
+    void closePromise.finally(() => this.pendingFfmpegCloses.delete(closePromise));
+  }
+
+  private persistManifest(): void {
+    const manifest = {
+      guildId: this.guildId,
+      sessionStartTs: this.sessionStartTs,
+      updatedAt: new Date().toISOString(),
+      chunks: this.sortedChunks(),
+    };
+    try {
+      fs.writeFileSync(
+        path.join(this.sessionDir, 'manifest.json'),
+        JSON.stringify(manifest, null, 2),
+        'utf8',
+      );
+    } catch (err: any) {
+      console.warn('[VOICE REC] Failed to persist manifest:', err?.message || err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Closes #79. Part of epic #85. **Stacked on #87** (which stacks on #86) — merge in order; GitHub retargets automatically.

- New `src/utils/voiceRecorder.ts`: one continuous `EndBehaviorType.Manual` subscription per user (verified: @discordjs/voice dedupes subscriptions, so dual-subscribe is impossible — the PCM is teed instead), written to 5-min rotating WAV chunks under `audio/<session>/<user>/` with a crash-safe `manifest.json`.
- Live captions unchanged: the teed PCM feeds a >3.5s-gap silence segmenter that emits utterance WAVs into the existing caption pipeline (guards intact, but now caption-only).
- Final transcript comes from a chronological batch pass over the chunks at `/voice stop` (existing `transcribeAudio` path, 15-min cap, progress message edited live), merged `[HH:MM:SS] username: text` across users. Live captions kept in the export under a raw section; fallback to captions if the batch pass yields nothing.
- Consent hardening: mid-session opt-out closes the user's live recording stream, not just future ones; VC leave finalizes the user's chunk.

## Test results
- `pnpm typecheck` ✅  `pnpm build` ✅  `pnpm format:check` ✅ (no test suite)
- Runtime validation (2-speaker call, crash test) is a manual deploy-time test plan — flagged in #79.

## Concurrent work
Stack: #86 → #87 → this → #81 → #80 → #83.