### PR TITLE
fix: caption echo/noise filtering + wall-clock checkpoint timestamps

### DIFF
--- a/src/commands/Voice.ts
+++ b/src/commands/Voice.ts
@@ -33,7 +33,7 @@ import {
   saveVoiceSession,
 } from '../utils/localdb';
 import { maybeDeleteSessionAudio } from '../utils/voiceLifecycle';
-import { ChunkMeta, SessionRecorder } from '../utils/voiceRecorder';
+import { ChunkMeta, mapPcmToWallMs, SessionRecorder } from '../utils/voiceRecorder';
 
 interface VoiceSession {
   connection: VoiceConnection;
@@ -931,7 +931,9 @@ async function forceLeave(interaction: CommandInteraction) {
  * local-Whisper serialization, the OpenAI fallback, and (relaxed) segment
  * quality filtering — and interleaves Whisper's per-segment start offsets
  * across ALL chunks and users: each segment gets an absolute timestamp
- * (chunk start + segment offset), everything is sorted by that time, and
+ * (segment offset mapped through the chunk's audio-time→wall-clock
+ * checkpoints, falling back to chunk start + offset for legacy chunks, #94),
+ * everything is sorted by that time, and
  * consecutive same-speaker segments within SEGMENT_MERGE_WINDOW_MS are merged
  * into one "[HH:MM:SS] username: text" line. This restores conversational
  * interleaving instead of one merged blob per 5-minute chunk (#93).
@@ -1022,8 +1024,16 @@ async function transcribeSessionRecordings(
     transcribedCount++;
     const chunkStartMs = new Date(chunk.startedAt).getTime();
     for (const seg of outcome.segments) {
+      // Chunk WAVs contain speech only (no packets arrive during silence), so
+      // Whisper's within-chunk offsets drift earlier than wall clock as
+      // silence accumulates (live test 2026-07-10: a line stamped 01:04:45
+      // held speech from ~01:07). Map the offset through the chunk's
+      // audio-time→wall-clock checkpoints; chunks from older manifests have
+      // no checkpoints, so keep chunkStart + offset as the fallback (#94).
+      const segStartMs = seg.startSec * 1000;
+      const atMs = mapPcmToWallMs(chunk.checkpoints, segStartMs) ?? chunkStartMs + segStartMs;
       entries.push({
-        atMs: chunkStartMs + seg.startSec * 1000,
+        atMs,
         username: chunk.username,
         text: seg.text,
       });
@@ -1096,15 +1106,46 @@ function normalizeForEchoCheck(text: string): string {
 const NORMALIZED_WHISPER_PROMPT = normalizeForEchoCheck(WHISPER_INITIAL_PROMPT);
 
 /**
+ * Distinctive multi-word core phrases from WHISPER_INITIAL_PROMPT (normalized).
+ * Whisper sometimes hallucinates a PARAPHRASE of the prompt rather than the
+ * prompt verbatim (live test 2026-07-10: "It's a casual, informal English
+ * voice chat." — "itsa…" vs "thisisa…" defeats the mutual-substring check).
+ * Any short output containing one of these full phrases is prompt bleed, not
+ * real conversation: nobody says "casual, informal English voice chat" on a
+ * call by coincidence. Phrases must be long/specific enough that legit speech
+ * mentioning e.g. "our discord call" does NOT contain them.
+ */
+const WHISPER_PROMPT_CORE_PHRASES = [
+  'casualinformalenglishvoicechat',
+  'discordcallbetweencolleagues',
+].map(normalizeForEchoCheck);
+
+/**
+ * Raw-length ceiling for the core-phrase echo check: a genuine long utterance
+ * could conceivably quote part of the prompt mid-sentence, but a short output
+ * that contains a full core phrase is essentially the prompt itself.
+ */
+const PROMPT_ECHO_MAX_LEN = 120;
+
+/**
  * True when a transcription is (substantially) the Whisper initial_prompt
- * echoed back: the normalized text is a substring of the normalized prompt (or
- * vice versa) and is long enough (>15 normalized chars) that a real utterance
- * matching it by coincidence is implausible (#93).
+ * echoed back (#93):
+ *  1. mutual-substring: the normalized text is a substring of the normalized
+ *     prompt (or vice versa) and is long enough (>15 normalized chars) that a
+ *     real utterance matching it by coincidence is implausible; OR
+ *  2. paraphrase: the text is short (<PROMPT_ECHO_MAX_LEN raw chars) and its
+ *     normalized form contains a distinctive prompt core phrase.
  */
 function isPromptEcho(text: string): boolean {
   const norm = normalizeForEchoCheck(text);
   if (norm.length <= 15) return false;
-  return NORMALIZED_WHISPER_PROMPT.includes(norm) || norm.includes(NORMALIZED_WHISPER_PROMPT);
+  if (NORMALIZED_WHISPER_PROMPT.includes(norm) || norm.includes(NORMALIZED_WHISPER_PROMPT)) {
+    return true;
+  }
+  if (text.length < PROMPT_ECHO_MAX_LEN) {
+    return WHISPER_PROMPT_CORE_PHRASES.some((phrase) => norm.includes(phrase));
+  }
+  return false;
 }
 
 /**
@@ -1181,8 +1222,17 @@ interface SegmentQualityFilter {
   maxNoSpeechProb: number;
 }
 
-/** Strict thresholds for live captions — posted in real time, so favor precision. */
-const CAPTION_SEGMENT_FILTER: SegmentQualityFilter = { minAvgLogprob: -1.0, maxNoSpeechProb: 0.6 };
+/**
+ * Strict thresholds for live captions — posted in real time, so favor
+ * precision. Tightened after the 2026-07-10 live test: background music/noise
+ * produced junk captions ("Relaxing audio available for free…") that the
+ * batch filter caught but the old caption thresholds (-1.0 / 0.6) let through.
+ * - minAvgLogprob -0.8: Whisper must be fairly confident in the decode; noise
+ *   hallucinations typically land below this.
+ * - maxNoSpeechProb 0.5: drop any segment Whisper thinks is more likely
+ *   non-speech than speech.
+ */
+const CAPTION_SEGMENT_FILTER: SegmentQualityFilter = { minAvgLogprob: -0.8, maxNoSpeechProb: 0.5 };
 
 /**
  * Relaxed thresholds for the batch pass (#93): the live test showed real
@@ -1333,9 +1383,25 @@ async function requestWhisperVerbose(
 }
 
 /**
+ * True when the majority of non-whitespace characters are non-ASCII. Our
+ * Whisper calls pin language=en, so a mostly non-latin result on an English
+ * call is a noise hallucination (live test 2026-07-10: "الف limbs",
+ * "It all memory remin desafukan"-style junk from background music), not
+ * speech. Used on the CAPTION path only — the batch pass has its own quality
+ * thresholds and is the durable record, so it stays recall-biased.
+ */
+function isMajorityNonAscii(text: string): boolean {
+  const chars = [...text].filter((c) => !/\s/.test(c));
+  if (chars.length === 0) return false;
+  const nonAscii = chars.filter((c) => (c.codePointAt(0) ?? 0) > 127).length;
+  return nonAscii * 2 > chars.length;
+}
+
+/**
  * Transcribe an audio file to a single merged string — the live-caption path.
  * Applies the STRICT caption segment filter and the shared sanitize() guards
- * (including the prompt-echo filter).
+ * (including the prompt-echo filter), plus a majority-non-ASCII drop (the
+ * session pins language=en, so non-latin output is hallucination).
  */
 async function transcribeAudio(
   filePath: string,
@@ -1345,18 +1411,34 @@ async function transcribeAudio(
   const data = await requestWhisperVerbose(filePath, speaker, sessionForTracking);
   if (data === null) return `[transcription failed for ${speaker}]`;
 
-  // Prefer good segments if available (both servers return them)
+  // Prefer good segments if available (both servers return them).
+  const rawSegments = Array.isArray(data.segments) ? data.segments : [];
   let t = '';
-  if (Array.isArray(data.segments)) {
-    const good = filterSegments(data.segments, CAPTION_SEGMENT_FILTER);
+  if (rawSegments.length > 0) {
+    const good = filterSegments(rawSegments, CAPTION_SEGMENT_FILTER);
     if (good.length > 0) {
       t = good
         .map((seg) => seg.text || '')
         .join(' ')
         .trim();
     }
+    // NO fallback to raw data.text here: if Whisper returned segments but
+    // every one failed the quality filter, the whole clip is noise — the raw
+    // text is exactly the hallucination we just filtered out (2026-07-10 live
+    // test: "cabeça.gov", "Relaxing audio available for free…"). The batch
+    // path keeps its text fallback; captions favor precision.
+  } else {
+    // Segment timing genuinely unavailable (some servers/formats return text
+    // only) — the raw text is all we have.
+    t = (data.text || '').trim();
   }
-  if (!t) t = (data.text || '').trim();
+
+  // language=en is pinned on the transcribe request, so a majority-non-ASCII
+  // result is a noise hallucination — never caption it.
+  if (isMajorityNonAscii(t)) {
+    console.log(`[VOICE] ⚠️ Dropped non-latin caption for ${speaker}: ${t.substring(0, 60)}`);
+    return '[no speech detected]';
+  }
 
   const cleanedT = sanitize(t);
   if (cleanedT && !cleanedT.includes('no speech')) return cleanedT;

--- a/src/utils/voiceRecorder.ts
+++ b/src/utils/voiceRecorder.ts
@@ -38,12 +38,52 @@ import * as prism from 'prism-media';
 
 const ffmpegPath: string = require('ffmpeg-static');
 
+/**
+ * Maps a position in a chunk's AUDIO timeline back to wall-clock time (#94).
+ * Chunk WAVs contain speech only (Discord sends no packets during silence),
+ * so audio time drifts earlier than wall clock as silence accumulates. A
+ * checkpoint is recorded whenever PCM arrives after a >CHECKPOINT_GAP_MS gap:
+ * "pcmMs of audio had been written when the wall clock read wallMs".
+ */
+export interface ChunkCheckpoint {
+  /** Audio time: milliseconds of PCM written to the chunk before this point. */
+  pcmMs: number;
+  /** Wall-clock epoch ms when the PCM write after the gap happened. */
+  wallMs: number;
+}
+
 export interface ChunkMeta {
   userId: string;
   username: string;
   /** ISO timestamp of (approximately) the first audio written to the chunk. */
   startedAt: string;
   filePath: string;
+  /**
+   * Audio-time → wall-clock checkpoints, in ascending pcmMs order. Absent on
+   * chunks recorded before #94 (older manifests) — callers must fall back to
+   * startedAt + offset for those.
+   */
+  checkpoints?: ChunkCheckpoint[];
+}
+
+/**
+ * Piecewise-maps an offset within a chunk's audio timeline (e.g. a Whisper
+ * segment start) to absolute wall-clock epoch ms using the chunk's
+ * checkpoints: find the last checkpoint at or before the offset, then add the
+ * audio elapsed since it. Returns null when no checkpoints exist (legacy
+ * chunk) so the caller can use the old startedAt + offset formula.
+ */
+export function mapPcmToWallMs(
+  checkpoints: ChunkCheckpoint[] | undefined,
+  pcmMs: number,
+): number | null {
+  if (!checkpoints || checkpoints.length === 0) return null;
+  let anchor = checkpoints[0];
+  for (const cp of checkpoints) {
+    if (cp.pcmMs <= pcmMs) anchor = cp;
+    else break;
+  }
+  return anchor.wallMs + (pcmMs - anchor.pcmMs);
 }
 
 export type UtteranceHandler = (
@@ -61,6 +101,10 @@ export type UtteranceHandler = (
 const CHUNK_ROTATE_MS = 5 * 60 * 1000; // rotate chunk files every 5 minutes
 const UTTERANCE_SILENCE_MS = 3500; // same boundary the old AfterSilence path used
 const STOP_FLUSH_TIMEOUT_MS = 10_000; // max wait for ffmpeg processes to finish at stop
+/** A gap in PCM arrival longer than this = silence worth checkpointing (#94). */
+const CHECKPOINT_GAP_MS = 1500;
+/** 48000 Hz * 2 channels * 2 bytes/sample = 192000 bytes/s = 192 bytes per ms of audio. */
+const PCM_BYTES_PER_MS = 192;
 
 interface UserRecorderState {
   userId: string;
@@ -71,6 +115,12 @@ interface UserRecorderState {
   // Continuous chunk writer
   chunkFfmpeg: ChildProcessWithoutNullStreams | null;
   chunkOpenedAt: number; // epoch ms
+  /** Metadata of the open chunk — checkpoints are appended to it live (#94). */
+  chunkMeta: ChunkMeta | null;
+  /** PCM bytes written to the open chunk so far (audio time = bytes / 192). */
+  chunkBytesWritten: number;
+  /** Wall-clock epoch ms of the previous PCM write to the open chunk. */
+  lastChunkWriteWallMs: number;
   // Per-utterance segmenter (live captions)
   uttFfmpeg: ChildProcessWithoutNullStreams | null;
   uttPath: string | null;
@@ -168,6 +218,9 @@ export class SessionRecorder {
       onPcm: () => {},
       chunkFfmpeg: null,
       chunkOpenedAt: 0,
+      chunkMeta: null,
+      chunkBytesWritten: 0,
+      lastChunkWriteWallMs: 0,
       uttFfmpeg: null,
       uttPath: null,
       uttTimer: null,
@@ -249,8 +302,22 @@ export class SessionRecorder {
     const now = Date.now();
     if (!state.chunkFfmpeg || now - state.chunkOpenedAt >= CHUNK_ROTATE_MS) {
       this.rotateChunk(state, now);
+    } else if (now - state.lastChunkWriteWallMs > CHECKPOINT_GAP_MS && state.chunkMeta) {
+      // Silence gap (#94): Discord sent no packets, so the chunk's audio
+      // timeline just fell behind wall clock. Checkpoint "this much audio had
+      // been written when the clock read now" so the batch pass can map
+      // Whisper segment offsets back to true wall-clock timestamps.
+      state.chunkMeta.checkpoints?.push({
+        pcmMs: state.chunkBytesWritten / PCM_BYTES_PER_MS,
+        wallMs: now,
+      });
+      // Persist so a crash mid-chunk keeps the checkpoints usable. Cheap:
+      // happens at most once per >1.5s silence gap, not per PCM frame.
+      this.persistManifest();
     }
     safeWrite(state.chunkFfmpeg, buf);
+    state.chunkBytesWritten += buf.length;
+    state.lastChunkWriteWallMs = now;
 
     // 2) Utterance segmenter for live captions: a >UTTERANCE_SILENCE_MS gap in
     //    decoded PCM arrival ends the current utterance (Discord sends no
@@ -273,12 +340,18 @@ export class SessionRecorder {
 
     state.chunkFfmpeg = ffmpeg;
     state.chunkOpenedAt = now;
-    this.chunks.push({
+    state.chunkBytesWritten = 0;
+    state.lastChunkWriteWallMs = now;
+    const meta: ChunkMeta = {
       userId: state.userId,
       username: state.username,
       startedAt: new Date(now).toISOString(),
       filePath,
-    });
+      // Anchor checkpoint: 0ms of audio written at chunk-open wall time (#94).
+      checkpoints: [{ pcmMs: 0, wallMs: now }],
+    };
+    state.chunkMeta = meta;
+    this.chunks.push(meta);
     // Persist on open so a crash mid-chunk still leaves the manifest entry
     // pointing at the (partially written but decodable) WAV.
     this.persistManifest();
@@ -289,6 +362,7 @@ export class SessionRecorder {
     if (!state.chunkFfmpeg) return;
     safeEndStdin(state.chunkFfmpeg);
     state.chunkFfmpeg = null;
+    state.chunkMeta = null;
   }
 
   private openUtterance(state: UserRecorderState, now: number): void {


### PR DESCRIPTION
## Summary
Fixes the three findings from the second live session (17-min planning call, epic #85):

1. **Prompt-echo paraphrase**: distinctive core-phrase check ('casual informal english voice chat', 'discord call between colleagues') catches Whisper paraphrases of the initial prompt that defeat the substring check ('It's a…' vs 'This is a…'). Verified against the observed leak.
2. **Caption noise**: caption path (only) now drops majority-non-ASCII output on en-pinned calls, tightens quality thresholds to −0.8/0.5, and no longer falls back to raw text when all segments fail the filter. Batch path untouched — it already filtered every hallucination in the live test.
3. **Timestamp drift**: chunks now record {pcmMs, wallMs} checkpoints at >1.5s PCM gaps (silence isn't written to disk, so audio-time drifts from wall-time); the batch pass maps segment offsets piecewise through them. Verified: synthetic 60s+120s gaps map correctly (old formula was minutes off — matches the 01:04:45-vs-01:07 drift observed live). Legacy chunks without checkpoints fall back to the old formula.

## Test results
- `pnpm typecheck` ✅ `pnpm build` ✅ `pnpm format:check` ✅
- node harness: echo checks 5/5, checkpoint mapping 8/8 (against compiled output)